### PR TITLE
Add rule for preventing multiple lines in conditionals

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,7 @@ var fluentChaining = require('./rules/fluent-chaining'),
     callIndentation = require('./rules/call-indentation'),
     noMultipleInlineFunctions = require('./rules/no-multiple-inline-functions'),
     noMultilineVarDeclaration = require('./rules/no-multiline-var-declaration'),
+    noMultilineConditionals = require('./rules/no-multiline-conditionals'),
     indent = require('./rules/indent');
 
 module.exports.rules = {
@@ -18,4 +19,5 @@ module.exports.rules = {
    'no-multiple-inline-functions': noMultipleInlineFunctions,
    'no-multiline-var-declarations': noMultilineVarDeclaration,
    'indent': indent,
+   'no-multiline-conditionals': noMultilineConditionals,
 };

--- a/lib/rules/fluent-chaining.js
+++ b/lib/rules/fluent-chaining.js
@@ -41,7 +41,8 @@ module.exports = {
          var firstLineIndent = helper.lineIndent(node.object.loc.start.line),
              lastLineIndent = helper.lineIndent(node.object.loc.end.line),
              expectedIndent = firstLineIndent + helper.indent,
-             propertyLineIndent = helper.lineIndent(node.property.loc.start.line);
+             propertyLineIndent = helper.lineIndent(node.property.loc.start.line),
+             sameLine = node.object.loc.start.line === node.object.loc.end.line;
 
          if (propertyLineIndent !== expectedIndent) {
             context.report({
@@ -62,9 +63,8 @@ module.exports = {
             });
          }
 
-         if (node.object.type === 'CallExpression' &&
-            node.object.loc.start.line !== node.object.loc.end.line &&
-            lastLineIndent !== propertyLineIndent) {
+
+         if (node.object.type === 'CallExpression' && !sameLine && lastLineIndent !== propertyLineIndent) {
             context.report({
                node: node.object,
                message: 'Call expression should be on a new line and indented'

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -437,7 +437,7 @@ module.exports = {
          * Looks for 'Models'
          */
          var calleeNode = node.parent, // FunctionExpression
-             indent, calleeParent, parentVarNode;
+             indent, calleeParent, parentVarNode, sameline;
 
          if (calleeNode.parent && (calleeNode.parent.type === 'Property' || calleeNode.parent.type === 'ArrayExpression')) {
             // If function is part of array or object, comma can be put at left
@@ -451,13 +451,13 @@ module.exports = {
          if (calleeNode.parent.type === 'CallExpression') {
             calleeParent = calleeNode.parent;
 
+            sameline = calleeParent.callee.loc.start.line === calleeParent.callee.loc.end.line;
+
             if (calleeNode.type !== 'FunctionExpression' && calleeNode.type !== 'ArrowFunctionExpression') {
                if (calleeParent && calleeParent.loc.start.line < node.loc.start.line) {
                   indent = getNodeIndent(calleeParent);
                }
-            } else if (isArgBeforeCalleeNodeMultiline(calleeNode) &&
-            calleeParent.callee.loc.start.line === calleeParent.callee.loc.end.line &&
-            !isNodeFirstInLine(calleeNode)) {
+            } else if (isArgBeforeCalleeNodeMultiline(calleeNode) && sameline && !isNodeFirstInLine(calleeNode)) {
                indent = getNodeIndent(calleeParent);
             }
          }
@@ -616,16 +616,16 @@ module.exports = {
       */
       function blockIndentationCheck(node) {
          var nodesToCheck = [],
-             indent, statementsWithProperties;
+             indent, statementsWithProperties, parentTypeCheck;
 
          // Skip inline blocks
          if (isSingleLineNode(node)) {
             return;
          }
 
-         // eslint-disable-next-line max-len
-         if (node.parent && (node.parent.type === 'FunctionExpression' || node.parent.type === 'FunctionDeclaration' || node.parent.type === 'ArrowFunctionExpression'
-         )) {
+         parentTypeCheck = [ 'FunctionExpression', 'FunctionDeclaration', 'ArrowFunctionExpression' ];
+
+         if (node.parent && _.contains(parentTypeCheck, node.parent.type)) {
             checkIndentInFunctionBlock(node);
             return;
          }

--- a/lib/rules/no-multiline-conditionals.js
+++ b/lib/rules/no-multiline-conditionals.js
@@ -1,0 +1,65 @@
+/**
+* Prevents multiple lines in the parentheses of if/else if/for/for in/while/do while statements.
+*
+* invalid exapample:
+* if (
+*     a < b &&
+*     b > c
+*     ) {
+*    b == c;
+* }
+*
+*/
+
+'use strict';
+
+
+module.exports = {
+
+   create: function(context) {
+
+      function checkStatement(node) {
+         var checkLine;
+
+         if (node.type === 'DoWhileStatement') {
+            // DoWhileStatement has the test at the end of the block.
+            checkLine = (node.loc.end.line !== node.test.loc.start.line) || (node.loc.end.line !== node.test.loc.end.line);
+         } else if (node.type === 'ForStatement') {
+            // ForStatement has 3 nodes in parens (init, test, update)
+            checkLine = (node.loc.start.line !== node.init.loc.start.line) || (node.loc.start.line !== node.init.loc.end.line);
+            checkLine = checkLine || (node.loc.start.line !== node.test.loc.start.line) || (node.loc.start.line !== node.test.loc.end.line);
+            checkLine = checkLine || node.loc.start.line !== node.update.loc.start.line || node.loc.start.line !== node.update.loc.end.line;
+         } else if (node.type === 'ForInStatement') {
+            // ForInStatement has 2 nodes in parens (left, right)
+            checkLine = (node.loc.start.line !== node.left.loc.start.line) || (node.loc.start.line !== node.left.loc.end.line);
+            checkLine = checkLine || (node.loc.start.line !== node.right.loc.start.line);
+            checkLine = checkLine || (node.loc.start.line !== node.right.loc.end.line);
+         } else {
+            // While and If have a test node that should be on the start line
+            checkLine = (node.loc.start.line !== node.test.loc.start.line) || (node.loc.start.line !== node.test.loc.end.line);
+         }
+
+         if (checkLine) {
+            context.report({
+               node: node,
+               message: '{{ identifier }} should not span multiple lines.',
+               data: {
+                  identifier: node.type,
+               },
+            });
+         }
+      }
+
+      return {
+         // loops
+         'WhileStatement': checkStatement,
+         'DoWhileStatement': checkStatement,
+         'ForStatement': checkStatement,
+         'ForInStatement': checkStatement,
+
+         // Choice
+         'IfStatement': checkStatement,
+      };
+   }
+
+};

--- a/tests/lib/rules/no-multiline-conditionals.test.js
+++ b/tests/lib/rules/no-multiline-conditionals.test.js
@@ -1,0 +1,140 @@
+/**
+ * @fileoverview Check that no array or object declarations span multiple lines.
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require('../../../lib/rules/no-multiline-conditionals'),
+    formatCode = require('../../code-helper'),
+    RuleTester = require('eslint').RuleTester,
+    ruleTester = new RuleTester(),
+    validExample, invalidIf, invalidIfElse, invalidFor, invalidWhile, invalidForIn, invalidDoWhile;
+
+validExample = formatCode(
+   'if (a < b) {',
+   '   while (a < b) {',
+   '      a += 1;',
+   '   }',
+   '}',
+   '',
+   'for (var i = 0; i < 4; i++) {',
+   '   a += i;',
+   '};',
+   '',
+   'do {',
+   '   a += b;',
+   '} while (a < 10);',
+   '',
+   'for (var str in arr) {',
+   '   a = a + str;',
+   '}'
+);
+
+invalidIf = formatCode(
+   'if (',
+   '   a === b',
+   ') {',
+   '   b = a -i;',
+   '}'
+);
+
+invalidIfElse = formatCode(
+   'if (a === b) {',
+   '   a += a;',
+   '} else if (',
+   '      b < a',
+   '     ) {',
+   '  b += 1;',
+   '}'
+);
+
+invalidWhile = formatCode(
+   'while (a < b &&',
+   '        c > d) {',
+   '   a += c;',
+   '}'
+);
+
+invalidFor = formatCode(
+   'for(',
+   '  var i = 0;',
+   '  i < 10;',
+   '  i++',
+   ') {',
+   '  a += i;',
+   '}'
+);
+
+invalidForIn = formatCode(
+   'for(',
+   'var str',
+   'in arr) {',
+   '  a = a + str;',
+   '}'
+);
+
+invalidDoWhile = formatCode(
+   'do {',
+   '   a += 1;',
+   '} while (',
+   '      a < 10',
+   ');'
+);
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+ruleTester.run('no-multiline-conditionals', rule, {
+   valid: [
+      validExample,
+   ],
+
+   invalid: [
+      {
+         code: invalidIf,
+         errors: [ {
+            message: 'IfStatement should not span multiple lines.',
+            type: 'IfStatement'
+         } ]
+      },
+      {
+         code: invalidIfElse,
+         errors: [ {
+            message: 'IfStatement should not span multiple lines.',
+            type: 'IfStatement'
+         } ]
+      },
+      {
+         code: invalidWhile,
+         errors: [ {
+            message: 'WhileStatement should not span multiple lines.',
+            type: 'WhileStatement'
+         } ]
+      },
+      {
+         code: invalidFor,
+         errors: [ {
+            message: 'ForStatement should not span multiple lines.',
+            type: 'ForStatement'
+         } ]
+      },
+      {
+         code: invalidDoWhile,
+         errors: [ {
+            message: 'DoWhileStatement should not span multiple lines.',
+            type: 'DoWhileStatement'
+         } ]
+      },
+      {
+         code: invalidForIn,
+         errors: [ {
+            message: 'ForInStatement should not span multiple lines.',
+            type: 'ForInStatement'
+         } ]
+      },
+   ]
+});


### PR DESCRIPTION
Rule prevents multiple lines in the parenthesis section of
if, while, do while, for, for in statements.
