### PR TITLE
Fix no-multiline-conditionals to accept for loops missing secionts

### DIFF
--- a/lib/rules/no-multiline-conditionals.js
+++ b/lib/rules/no-multiline-conditionals.js
@@ -26,9 +26,19 @@ module.exports = {
             checkLine = (node.loc.end.line !== node.test.loc.start.line) || (node.loc.end.line !== node.test.loc.end.line);
          } else if (node.type === 'ForStatement') {
             // ForStatement has 3 nodes in parens (init, test, update)
-            checkLine = (node.loc.start.line !== node.init.loc.start.line) || (node.loc.start.line !== node.init.loc.end.line);
-            checkLine = checkLine || (node.loc.start.line !== node.test.loc.start.line) || (node.loc.start.line !== node.test.loc.end.line);
-            checkLine = checkLine || node.loc.start.line !== node.update.loc.start.line || node.loc.start.line !== node.update.loc.end.line;
+            checkLine = false;
+            if (node.init) {
+               checkLine = checkLine || (node.loc.start.line !== node.init.loc.start.line);
+               checkLine = checkLine || (node.loc.start.line !== node.init.loc.end.line);
+            }
+            if (node.test) {
+               checkLine = checkLine || (node.loc.start.line !== node.test.loc.start.line);
+               checkLine = checkLine || (node.loc.start.line !== node.test.loc.end.line);
+            }
+            if (node.update) {
+               checkLine = checkLine || node.loc.start.line !== node.update.loc.start.line;
+               checkLine = checkLine || node.loc.start.line !== node.update.loc.end.line;
+            }
          } else if (node.type === 'ForInStatement') {
             // ForInStatement has 2 nodes in parens (left, right)
             checkLine = (node.loc.start.line !== node.left.loc.start.line) || (node.loc.start.line !== node.left.loc.end.line);

--- a/tests/lib/rules/no-multiline-conditionals.test.js
+++ b/tests/lib/rules/no-multiline-conditionals.test.js
@@ -30,6 +30,16 @@ validExample = formatCode(
    '',
    'for (var str in arr) {',
    '   a = a + str;',
+   '}',
+   '',
+   'for (var i = 0; i < 3;) {',
+   '  i += 2;',
+   '}',
+   'for (;i < 2; i++) {',
+   '  a = i;',
+   '}',
+   'for (;i < 3;) {',
+   '  i++;',
    '}'
 );
 


### PR DESCRIPTION
no-multiline-conditionals was throwing an error a for loop did not initialize the variable or update. 

example:

```
for (var i = 0; i < 4) {
   i += 1;
}
```

would throw an error because it has no update section. 
