### PR TITLE
New rules for empty object and array spacing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,7 @@ var fluentChaining = require('./rules/fluent-chaining'),
     noMultilineVarDeclaration = require('./rules/no-multiline-var-declaration'),
     noMultilineConditionals = require('./rules/no-multiline-conditionals'),
     emptyObjectSpacing = require('./rules/empty-object-spacing'),
+    emptyArraySpacing = require('./rules/empty-array-spacing'),
     indent = require('./rules/indent');
 
 module.exports.rules = {
@@ -22,4 +23,5 @@ module.exports.rules = {
    'indent': indent,
    'no-multiline-conditionals': noMultilineConditionals,
    'empty-object-spacing': emptyObjectSpacing,
+   'empty-array-spacing': emptyArraySpacing,
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,7 @@ var fluentChaining = require('./rules/fluent-chaining'),
     noMultipleInlineFunctions = require('./rules/no-multiple-inline-functions'),
     noMultilineVarDeclaration = require('./rules/no-multiline-var-declaration'),
     noMultilineConditionals = require('./rules/no-multiline-conditionals'),
+    emptyObjectSpacing = require('./rules/empty-object-spacing'),
     indent = require('./rules/indent');
 
 module.exports.rules = {
@@ -20,4 +21,5 @@ module.exports.rules = {
    'no-multiline-var-declarations': noMultilineVarDeclaration,
    'indent': indent,
    'no-multiline-conditionals': noMultilineConditionals,
+   'empty-object-spacing': emptyObjectSpacing,
 };

--- a/lib/rules/empty-array-spacing.js
+++ b/lib/rules/empty-array-spacing.js
@@ -1,0 +1,61 @@
+/**
+ * @fileoverview Ensures consistent spacing in empty array declarations
+ */
+
+'use strict';
+
+module.exports = {
+
+   meta: {
+      docs: {
+         description: 'enforce consistent spacing inside empty array declarations',
+         category: 'Stylistic Issues',
+      },
+
+      schema: [
+         { 'enum': [ 'always', 'never' ] },
+      ],
+   },
+
+   create: function(context) {
+      var spaceRequired = context.options[0] === 'always',
+          sourceCode = context.getSourceCode();
+
+      function validateArray(node) {
+         var first, last, spaced;
+
+         // Only check empty array declarations
+         if (node.elements.length > 0) {
+            return;
+         }
+
+         first = sourceCode.getFirstToken(node);
+         // We are already checking that the declaration is empty, so the second Token will be the closing bracket
+         last = sourceCode.getTokenAfter(first);
+
+         spaced = sourceCode.isSpaceBetweenTokens(first, last);
+
+         if (spaceRequired && !spaced) {
+            context.report({
+               node: node,
+               message: 'Empty array requires space',
+            });
+            return;
+         }
+
+         if (!spaceRequired && spaced) {
+            context.report({
+               node: node,
+               message: 'Empty array should not contain whitespace',
+            });
+            return;
+         }
+      }
+
+      return {
+         'ArrayPattern': validateArray,
+         'ArrayExpression': validateArray,
+      };
+   },
+
+};

--- a/lib/rules/empty-object-spacing.js
+++ b/lib/rules/empty-object-spacing.js
@@ -1,0 +1,61 @@
+/**
+ * @fileoverview Ensures consistent spacing in empty object declarations
+ */
+
+'use strict';
+
+module.exports = {
+
+   meta: {
+      docs: {
+         description: 'enforce consistent spacing inside empty object declarations',
+         category: 'Stylistic Issues',
+      },
+
+      schema: [
+         { 'enum': [ 'always', 'never' ] },
+      ],
+   },
+
+   create: function(context) {
+      var spaceRequired = context.options[0] === 'always',
+          sourceCode = context.getSourceCode();
+
+      function validateObj(node) {
+         var first, last, spaced;
+
+         // Only check empty object declarations
+         if (node.properties.length > 0) {
+            return;
+         }
+
+         first = sourceCode.getFirstToken(node);
+         // We are already checking that the declaration is empty, so the second Token will be the closing brace
+         last = sourceCode.getTokenAfter(first);
+
+         spaced = sourceCode.isSpaceBetweenTokens(first, last);
+
+         if (spaceRequired && !spaced) {
+            context.report({
+               node: node,
+               message: 'Empty object requires space',
+            });
+            return;
+         }
+
+         if (!spaceRequired && spaced) {
+            context.report({
+               node: node,
+               message: 'Empty object should not contain whitespace',
+            });
+            return;
+         }
+      }
+
+      return {
+         'ObjectPattern': validateObj,
+         'ObjectExpression': validateObj,
+      };
+   },
+
+};

--- a/tests/lib/rules/empty-array-spacing.test.js
+++ b/tests/lib/rules/empty-array-spacing.test.js
@@ -4,19 +4,24 @@
 
 'use strict';
 
-var rule = require('../../../lib/rules/empty-object-spacing.js'),
+var rule = require('../../../lib/rules/empty-array-spacing.js'),
     formatCode = require('../../code-helper'),
     RuleTester = require('eslint').RuleTester,
     ruleTester = new RuleTester(),
     spacedExample, notSpacedExample, shouldBeSkipped;
 
-spacedExample = formatCode('var obj = { };');
-notSpacedExample = formatCode('var obj = {};');
+spacedExample = formatCode('var arr = [ ];');
+notSpacedExample = formatCode('var arr = [];');
 shouldBeSkipped = formatCode(
-   'var obj = { a: 1 };',
-   '    obj = {a: 1},',
-   '    obj2 = {b: 1 },',
-   '    obj3 = { c: 1};');
+   'var arr = [1,2,3],',
+   '    arr2 = [ 1,2,3],',
+   '    arr3 = [1,2,3 ],',
+   '    arr4 = [ 1,2,3, ],',
+   '    arr5 = [ 1, 2, 3, ];',
+   'arr[1] = 1;',
+   'arr[ 1 ] = 2;',
+   'arr[1 ] = 2;',
+   'arr[ 1] = 3;');
 
 ruleTester.run('empty-object-spacing', rule, {
    valid: [
@@ -45,8 +50,8 @@ ruleTester.run('empty-object-spacing', rule, {
          options: [ 'never' ],
          errors: [
             {
-               message: 'Empty object should not contain whitespace',
-               type: 'ObjectExpression',
+               message: 'Empty array should not contain whitespace',
+               type: 'ArrayExpression',
             }
          ],
       },
@@ -55,8 +60,8 @@ ruleTester.run('empty-object-spacing', rule, {
          options: [ 'always' ],
          errors: [
             {
-               message: 'Empty object requires space',
-               type: 'ObjectExpression',
+               message: 'Empty array requires space',
+               type: 'ArrayExpression',
             }
          ],
       },

--- a/tests/lib/rules/empty-object-spacing.test.js
+++ b/tests/lib/rules/empty-object-spacing.test.js
@@ -1,0 +1,64 @@
+/**
+ * @fileoverview Ensure consitent spacing in empty object declarations
+ */
+
+'use strict';
+
+var rule = require('../../../lib/rules/empty-object-spacing.js'),
+    formatCode = require('../../code-helper'),
+    RuleTester = require('eslint').RuleTester,
+    ruleTester = new RuleTester(),
+    spacedExample, notSpacedExample, shouldBeSkipped;
+
+spacedExample = formatCode('var obj = { };');
+notSpacedExample = formatCode('var obj = {};');
+shouldBeSkipped = formatCode(
+   'var obj = { a: 1 };',
+   '    obj = {a: 1},',
+   '    obj2 = {b: 1 },',
+   '    obj3 = { c: 1};');
+
+ruleTester.run('empty-object-spacing', rule, {
+   valid: [
+      {
+         code: spacedExample,
+         options: [ 'always' ],
+      },
+      {
+         code: notSpacedExample,
+         options: [ 'never' ],
+      },
+      {
+         code: shouldBeSkipped,
+         options: [ 'always' ],
+      },
+      {
+         code: shouldBeSkipped,
+         options: [ 'never' ],
+      },
+   ],
+
+
+   invalid: [
+      {
+         code: spacedExample,
+         options: [ 'never' ],
+         errors: [
+            {
+               message: 'Empty object should not contain whitespace',
+               type: 'ObjectExpression',
+            }
+         ],
+      },
+      {
+         code: notSpacedExample,
+         options: [ 'always' ],
+         errors: [
+            {
+               message: 'Empty object requires space',
+               type: 'ObjectExpression',
+            }
+         ],
+      },
+   ],
+});


### PR DESCRIPTION
This commit adds 2 new rules. One for spacing in empty objects and one for spacing in empty arrays.

This addresses issue 2 found in https://github.com/silvermine/serverless-plugin-external-sns-events/issues/10