### PR TITLE
Added uninitialized-last rule

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,7 @@ var fluentChaining = require('./rules/fluent-chaining'),
     noMultilineConditionals = require('./rules/no-multiline-conditionals'),
     emptyObjectSpacing = require('./rules/empty-object-spacing'),
     emptyArraySpacing = require('./rules/empty-array-spacing'),
+    uninitializedLast = require('./rules/uninitialized-last'),
     indent = require('./rules/indent');
 
 module.exports.rules = {
@@ -24,4 +25,5 @@ module.exports.rules = {
    'no-multiline-conditionals': noMultilineConditionals,
    'empty-object-spacing': emptyObjectSpacing,
    'empty-array-spacing': emptyArraySpacing,
+   'uninitialized-last': uninitializedLast,
 };

--- a/lib/rules/uninitialized-last.js
+++ b/lib/rules/uninitialized-last.js
@@ -1,0 +1,45 @@
+/**
+ * @fileoverview Ensures uninitialized variables come last in the variable declaration chain
+ */
+
+'use strict';
+
+var _ = require('underscore');
+
+module.exports = {
+
+   create: function(context) {
+
+      function validateVar(node) {
+         var initialized, uninitialized, firstUninitialized, lastInitialized;
+
+         if (node.declarations && node.declarations.length > 1) {
+            initialized = _.filter(node.declarations, function(decl) {
+               return decl.init !== null;
+            });
+
+            uninitialized = _.filter(node.declarations, function(decl) {
+               return decl.init === null;
+            });
+
+            if (initialized.length > 0 && uninitialized.length > 0) {
+               lastInitialized = _.indexOf(node.declarations, _.last(initialized));
+               firstUninitialized = _.indexOf(node.declarations, _.first(uninitialized));
+
+               if (firstUninitialized < lastInitialized) {
+                  context.report({
+                     node: node,
+                     message: 'Uninitialized variables should come last in the declaration.',
+                  });
+               }
+            }
+         }
+
+      }
+
+      return {
+         'VariableDeclaration': validateVar,
+      };
+   },
+
+};

--- a/tests/lib/rules/uninitialized-last.test.js
+++ b/tests/lib/rules/uninitialized-last.test.js
@@ -1,0 +1,67 @@
+/**
+* @fileoverview Check that uninitialized var declarations come last.
+*/
+'use strict';
+
+var rule = require('../../../lib/rules/uninitialized-last'),
+    formatCode = require('../../code-helper'),
+    RuleTester = require('eslint').RuleTester,
+    ruleTester = new RuleTester(),
+    invalidExample, validExample;
+
+validExample = formatCode(
+   'var myArray = [],',
+   '    myObj;',
+   '',
+   'var var1, var2;',
+   '',
+   'var num1 = 1,',
+   '    num2 = 2,',
+   '    num3, num4, num5;',
+   '',
+   'var num6 = 1, var3;'
+);
+
+invalidExample = formatCode(
+   'var var1,',
+   '    var2 = 4;',
+   '',
+   'var num1, num2, num3 = 1;',
+   '',
+   'var a = 5,',
+   '    b,',
+   '    c = 6;',
+   '',
+   'var d = 2, e, c, f = 1;'
+);
+
+
+ruleTester.run('uninitialized-last', rule, {
+   valid: [
+      validExample,
+   ],
+
+   invalid: [
+      {
+         code: invalidExample,
+         errors: [
+            {
+               message: 'Uninitialized variables should come last in the declaration.',
+               type: 'VariableDeclaration'
+            },
+            {
+               message: 'Uninitialized variables should come last in the declaration.',
+               type: 'VariableDeclaration'
+            },
+            {
+               message: 'Uninitialized variables should come last in the declaration.',
+               type: 'VariableDeclaration'
+            },
+            {
+               message: 'Uninitialized variables should come last in the declaration.',
+               type: 'VariableDeclaration'
+            },
+         ],
+      },
+   ]
+});


### PR DESCRIPTION
This adds a rule to enforce our standard of putting the uninitialized variables last in the variable declaration chain.