### PR TITLE
Fix eslint errors after new rules were added

### DIFF
--- a/lib/rules/array-indentation.js
+++ b/lib/rules/array-indentation.js
@@ -36,6 +36,6 @@ module.exports = function(context) {
          if (node.loc.start.line !== node.loc.end.line) {
             validateArrayIndentation(node);
          }
-      }
+      },
    };
 };

--- a/lib/rules/call-indentation.js
+++ b/lib/rules/call-indentation.js
@@ -138,7 +138,7 @@ module.exports = function(context) {
          if (node.callee.loc.end.line !== node.loc.end.line) {
             validateCallIndentation(node);
          }
-      }
+      },
    };
 
 };

--- a/lib/rules/fluent-chaining.js
+++ b/lib/rules/fluent-chaining.js
@@ -68,7 +68,7 @@ module.exports = {
          if (node.object.type === 'CallExpression' && !sameLine && lastLineIndent !== propertyLineIndent) {
             context.report({
                node: node.object,
-               message: 'Call expression should be on a new line and indented'
+               message: 'Call expression should be on a new line and indented',
             });
          }
       }
@@ -98,7 +98,7 @@ module.exports = {
          } else {
             context.report({
                node: node,
-               message: 'Member expression should not span more than 2 lines'
+               message: 'Member expression should not span more than 2 lines',
             });
          }
       }
@@ -108,8 +108,8 @@ module.exports = {
       //--------------------------------------------------------------------------
 
       return {
-         'MemberExpression': checkMemberExpression
+         'MemberExpression': checkMemberExpression,
       };
 
-   }
+   },
 };

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -31,7 +31,7 @@ module.exports = {
       docs: {
          description: 'enforce consistent indentation',
          category: 'Stylistic Issues',
-         recommended: false
+         recommended: false,
       },
 
       fixable: 'whitespace',
@@ -40,75 +40,75 @@ module.exports = {
          {
             oneOf: [
                {
-                  'enum': [ 'tab' ]
+                  'enum': [ 'tab' ],
                },
                {
                   type: 'integer',
-                  minimum: 0
-               }
-            ]
+                  minimum: 0,
+               },
+            ],
          },
          {
             type: 'object',
             properties: {
                SwitchCase: {
                   type: 'integer',
-                  minimum: 0
+                  minimum: 0,
                },
                VariableDeclarator: {
                   oneOf: [
                      {
                         type: 'integer',
-                        minimum: 0
+                        minimum: 0,
                      },
                      {
                         type: 'object',
                         properties: {
                            'var': {
                               type: 'integer',
-                              minimum: 0
+                              minimum: 0,
                            },
                            'let': {
                               type: 'integer',
-                              minimum: 0
+                              minimum: 0,
                            },
                            'const': {
                               type: 'integer',
-                              minimum: 0
-                           }
-                        }
-                     }
-                  ]
+                              minimum: 0,
+                           },
+                        },
+                     },
+                  ],
                },
                VariableDeclaratorOffset: {
                   oneOf: [
                      {
                         type: 'integer',
-                        minimum: Number.MIN_VALUE
+                        minimum: Number.MIN_VALUE,
                      },
                      {
                         type: 'object',
                         properties: {
                            'var': {
                               type: 'integer',
-                              minimum: Number.MIN_VALUE
+                              minimum: Number.MIN_VALUE,
                            },
                            'let': {
                               type: 'integer',
-                              minimum: Number.MIN_VALUE
+                              minimum: Number.MIN_VALUE,
                            },
                            'const': {
                               type: 'integer',
-                              minimum: Number.MIN_VALUE
-                           }
-                        }
-                     }
-                  ]
-               }
+                              minimum: Number.MIN_VALUE,
+                           },
+                        },
+                     },
+                  ],
+               },
             },
-            additionalProperties: false
-         }
-      ]
+            additionalProperties: false,
+         },
+      ],
    },
 
    create: function(context) {
@@ -126,13 +126,13 @@ module.exports = {
          VariableDeclarator: {
             'var': DEFAULT_VARIABLE_INDENT,
             'let': DEFAULT_VARIABLE_INDENT,
-            'const': DEFAULT_VARIABLE_INDENT
+            'const': DEFAULT_VARIABLE_INDENT,
          },
          VariableDeclaratorOffset: {
             'var': DEFAULT_VARIABLE_INDENT_OFFSET,
             'let': DEFAULT_VARIABLE_INDENT_OFFSET,
-            'const': DEFAULT_VARIABLE_INDENT_OFFSET
-         }
+            'const': DEFAULT_VARIABLE_INDENT_OFFSET,
+         },
       };
 
 
@@ -155,7 +155,7 @@ module.exports = {
                options.VariableDeclarator = {
                   'var': variableDeclaratorRules,
                   'let': variableDeclaratorRules,
-                  'const': variableDeclaratorRules
+                  'const': variableDeclaratorRules,
                };
             } else if (typeof variableDeclaratorRules === 'object') {
                lodashAssign(options.VariableDeclarator, variableDeclaratorRules);
@@ -167,7 +167,7 @@ module.exports = {
                options.VariableDeclaratorOffset = {
                   'var': variableDeclaratorOffsetRules,
                   'let': variableDeclaratorOffsetRules,
-                  'const': variableDeclaratorOffsetRules
+                  'const': variableDeclaratorOffsetRules,
                };
             } else if (typeof variableDeclaratorOffsetRules === 'object') {
                lodashAssign(options.VariableDeclaratorOffset, variableDeclaratorOffsetRules);
@@ -177,7 +177,7 @@ module.exports = {
 
       indentPattern = {
          normal: indentType === 'space' ? /^ +/ : /^\t+/,
-         excludeCommas: indentType === 'space' ? /^[ ,]+/ : /^[\t,]+/
+         excludeCommas: indentType === 'space' ? /^[ ,]+/ : /^[\t,]+/,
       };
 
       caseIndentStore = {};
@@ -198,7 +198,7 @@ module.exports = {
             needed: needed,
             type: indentType,
             characters: needed === 1 ? 'character' : 'characters',
-            gotten: gotten
+            gotten: gotten,
          };
          indentChar = indentType === 'space' ? ' ' : '\t';
 
@@ -217,12 +217,12 @@ module.exports = {
                if (isLastNodeCheck === true) {
                   rangeToFix = [
                      node.range[1] - 1,
-                     node.range[1] - 1
+                     node.range[1] - 1,
                   ];
                } else {
                   rangeToFix = [
                      node.range[0],
-                     node.range[0]
+                     node.range[0],
                   ];
                }
 
@@ -234,12 +234,12 @@ module.exports = {
             if (isLastNodeCheck === true) {
                rangeToFix = [
                   node.range[1] - (gotten - needed) - 1,
-                  node.range[1] - 1
+                  node.range[1] - 1,
                ];
             } else {
                rangeToFix = [
                   node.range[0] - (gotten - needed),
-                  node.range[0]
+                  node.range[0],
                ];
             }
 
@@ -254,14 +254,14 @@ module.exports = {
                loc: loc,
                message: MESSAGE,
                data: msgContext,
-               fix: getFixerFunction()
+               fix: getFixerFunction(),
             });
          } else {
             context.report({
                node: node,
                message: MESSAGE,
                data: msgContext,
-               fix: getFixerFunction()
+               fix: getFixerFunction(),
             });
          }
       }
@@ -636,7 +636,7 @@ module.exports = {
          * not from the beginning of the block.
          */
          statementsWithProperties = [
-            'IfStatement', 'WhileStatement', 'ForStatement', 'ForInStatement', 'ForOfStatement', 'DoWhileStatement', 'ClassDeclaration'
+            'IfStatement', 'WhileStatement', 'ForStatement', 'ForInStatement', 'ForOfStatement', 'DoWhileStatement', 'ClassDeclaration',
          ];
 
          if (node.parent && statementsWithProperties.indexOf(node.parent.type) !== -1 && isNodeBodyBlock(node)) {
@@ -819,8 +819,8 @@ module.exports = {
             caseIndent = expectedCaseIndent(node);
 
             checkNodesIndent(node.consequent, caseIndent + indentSize);
-         }
+         },
       };
 
-   }
+   },
 };

--- a/lib/rules/no-multiline-conditionals.js
+++ b/lib/rules/no-multiline-conditionals.js
@@ -70,6 +70,6 @@ module.exports = {
          // Choice
          'IfStatement': checkStatement,
       };
-   }
+   },
 
 };

--- a/lib/rules/no-multiple-inline-functions.js
+++ b/lib/rules/no-multiple-inline-functions.js
@@ -21,7 +21,7 @@ module.exports = function(context) {
             if (hasFunctionArgument) {
                context.report({
                   node: argument,
-                  message: 'Too many function declarations used as arguments'
+                  message: 'Too many function declarations used as arguments',
                });
             }
 
@@ -35,6 +35,6 @@ module.exports = function(context) {
    //--------------------------------------------------------------------------
 
    return {
-      'CallExpression': checkCallExpression
+      'CallExpression': checkCallExpression,
    };
 };

--- a/tests/lib/rules/array-indentation.test.js
+++ b/tests/lib/rules/array-indentation.test.js
@@ -44,7 +44,7 @@ validExample2 = formatCode(
 ruleTester.run('array-indentation', rule, {
    valid: [
       validExample1,
-      validExample2
+      validExample2,
    ],
 
    invalid: [
@@ -52,8 +52,8 @@ ruleTester.run('array-indentation', rule, {
          code: invalidExample,
          errors: [ {
             message: 'Array expressions must begin and end with the same indentation',
-            type: 'ArrayExpression'
-         } ]
-      }
-   ]
+            type: 'ArrayExpression',
+         } ],
+      },
+   ],
 });

--- a/tests/lib/rules/call-indentation.test.js
+++ b/tests/lib/rules/call-indentation.test.js
@@ -29,7 +29,7 @@ invalidExamples = [
       errors: [
          {
             message: MSG_CALL_SAME_INDENT,
-            type: 'CallExpression'
+            type: 'CallExpression',
          },
       ],
    },
@@ -74,7 +74,7 @@ invalidExamples = [
       errors: [
          {
             message: MSG_CALL_SAME_INDENT,
-            type: 'CallExpression'
+            type: 'CallExpression',
          },
          {
             message: MSG_PAREN_ON_NEW_LINE,
@@ -154,7 +154,7 @@ invalidExamples = [
       errors: [
          {
             message: MSG_CALL_SAME_INDENT,
-            type: 'CallExpression'
+            type: 'CallExpression',
          },
          {
             message: MSG_ARG_ON_NEW_LINE,
@@ -189,11 +189,11 @@ invalidExamples = [
       errors: [
          {
             message: MSG_MULTIPLE_MULTILINE_ARGS,
-            type: 'CallExpression'
+            type: 'CallExpression',
          },
          {
             message: MSG_MULTIPLE_MULTILINE_ARGS,
-            type: 'CallExpression'
+            type: 'CallExpression',
          },
       ],
    },

--- a/tests/lib/rules/empty-array-spacing.test.js
+++ b/tests/lib/rules/empty-array-spacing.test.js
@@ -21,7 +21,8 @@ shouldBeSkipped = formatCode(
    'arr[1] = 1;',
    'arr[ 1 ] = 2;',
    'arr[1 ] = 2;',
-   'arr[ 1] = 3;');
+   'arr[ 1] = 3;'
+);
 
 ruleTester.run('empty-object-spacing', rule, {
    valid: [

--- a/tests/lib/rules/empty-array-spacing.test.js
+++ b/tests/lib/rules/empty-array-spacing.test.js
@@ -52,7 +52,7 @@ ruleTester.run('empty-object-spacing', rule, {
             {
                message: 'Empty array should not contain whitespace',
                type: 'ArrayExpression',
-            }
+            },
          ],
       },
       {
@@ -62,7 +62,7 @@ ruleTester.run('empty-object-spacing', rule, {
             {
                message: 'Empty array requires space',
                type: 'ArrayExpression',
-            }
+            },
          ],
       },
    ],

--- a/tests/lib/rules/empty-object-spacing.test.js
+++ b/tests/lib/rules/empty-object-spacing.test.js
@@ -16,7 +16,8 @@ shouldBeSkipped = formatCode(
    'var obj = { a: 1 };',
    '    obj = {a: 1},',
    '    obj2 = {b: 1 },',
-   '    obj3 = { c: 1};');
+   '    obj3 = { c: 1};'
+);
 
 ruleTester.run('empty-object-spacing', rule, {
    valid: [

--- a/tests/lib/rules/empty-object-spacing.test.js
+++ b/tests/lib/rules/empty-object-spacing.test.js
@@ -47,7 +47,7 @@ ruleTester.run('empty-object-spacing', rule, {
             {
                message: 'Empty object should not contain whitespace',
                type: 'ObjectExpression',
-            }
+            },
          ],
       },
       {
@@ -57,7 +57,7 @@ ruleTester.run('empty-object-spacing', rule, {
             {
                message: 'Empty object requires space',
                type: 'ObjectExpression',
-            }
+            },
          ],
       },
    ],

--- a/tests/lib/rules/fluent-chaining.test.js
+++ b/tests/lib/rules/fluent-chaining.test.js
@@ -29,9 +29,9 @@ function checkManyLinesError() {
       errors: [
          {
             message: 'Member expression should not span more than 2 lines',
-            type: 'MemberExpression'
-         }
-      ]
+            type: 'MemberExpression',
+         },
+      ],
    };
 }
 
@@ -47,9 +47,9 @@ function checkManyLinesCommentError() {
       errors: [
          {
             message: 'Member expression should not span more than 2 lines',
-            type: 'MemberExpression'
-         }
-      ]
+            type: 'MemberExpression',
+         },
+      ],
    };
 }
 
@@ -64,14 +64,14 @@ function checkNewLineError() {
       errors: [
          {
             message: 'Identifier "c" should be on a new line',
-            type: 'Identifier'
-         }
+            type: 'Identifier',
+         },
       ],
       output: formatCode(
          'a()',
          '   .b()',
          '   .c;'
-      )
+      ),
    };
 }
 
@@ -84,22 +84,22 @@ function checkNewLineErrorWithTabOption() {
       errors: [
          {
             message: 'Identifier "c" should be on a new line',
-            type: 'Identifier'
-         }
+            type: 'Identifier',
+         },
       ],
       options: [ { IndentChar: 'tab', IndentAmount: 1 } ],
       output: formatCode(
          'a()',
          '\t.b()',
          '\t.c;'
-      )
+      ),
    };
 }
 
 function spacingErrorMessage(identifier, indentAmount, indentChar) {
    return {
       message: 'Expected identifier "' + identifier + '" to be indented ' + indentAmount + ' chars (char: "' + indentChar + '")',
-      type: 'Identifier'
+      type: 'Identifier',
    };
 }
 
@@ -115,7 +115,7 @@ function checkSpacingError() {
       output: formatCode(
          'a()',
          '   .b();'
-      )
+      ),
    };
 }
 
@@ -132,7 +132,7 @@ function checkSpacingErrorWithIndentOption() {
       output: formatCode(
          'a()',
          '    .b();'
-      )
+      ),
    };
 }
 
@@ -149,7 +149,7 @@ function checkSpacingErrorWithTabOption() {
       output: formatCode(
          'a()',
          '\t.b();'
-      )
+      ),
    };
 }
 
@@ -170,7 +170,7 @@ function checkSpacingErrorWhenCallHasFunctionArguments() {
       errors: [
          spacingErrorMessage('then', 3, ' '),
       ],
-      output: code // output should be unchanged
+      output: code, // output should be unchanged
    };
 }
 
@@ -190,14 +190,14 @@ function checkSpacingErrorWhenNested() {
       errors: [
          spacingErrorMessage('then', 6, ' '),
          spacingErrorMessage('then', 6, ' '),
-      ]
+      ],
    };
 }
 
 function chainingIndentationMatchErrorMessage() {
    return {
       message: 'Call expression should be on a new line and indented',
-      type: 'CallExpression'
+      type: 'CallExpression',
    };
 }
 
@@ -217,7 +217,7 @@ function checkChainingIndentationError1() {
       ),
       errors: [
          chainingIndentationMatchErrorMessage(),
-      ]
+      ],
    };
 }
 
@@ -234,7 +234,7 @@ function checkChainingIndentationError2() {
       ),
       errors: [
          chainingIndentationMatchErrorMessage(),
-      ]
+      ],
    };
 }
 
@@ -244,7 +244,7 @@ function checkChainingIndentationError2() {
 
 ruleTester.run('fluent-chaining - no false-positives for valid code', fluentChaining, {
    valid: [
-      fs.readFileSync(path.join(__dirname, '/fluent-chaining.valid.js'), 'utf8') // eslint-disable-line no-sync
+      fs.readFileSync(path.join(__dirname, '/fluent-chaining.valid.js'), 'utf8'), // eslint-disable-line no-sync
    ],
    invalid: [],
 });

--- a/tests/lib/rules/no-multiline-conditionals.test.js
+++ b/tests/lib/rules/no-multiline-conditionals.test.js
@@ -108,43 +108,43 @@ ruleTester.run('no-multiline-conditionals', rule, {
          code: invalidIf,
          errors: [ {
             message: 'IfStatement should not span multiple lines.',
-            type: 'IfStatement'
-         } ]
+            type: 'IfStatement',
+         } ],
       },
       {
          code: invalidIfElse,
          errors: [ {
             message: 'IfStatement should not span multiple lines.',
-            type: 'IfStatement'
-         } ]
+            type: 'IfStatement',
+         } ],
       },
       {
          code: invalidWhile,
          errors: [ {
             message: 'WhileStatement should not span multiple lines.',
-            type: 'WhileStatement'
-         } ]
+            type: 'WhileStatement',
+         } ],
       },
       {
          code: invalidFor,
          errors: [ {
             message: 'ForStatement should not span multiple lines.',
-            type: 'ForStatement'
-         } ]
+            type: 'ForStatement',
+         } ],
       },
       {
          code: invalidDoWhile,
          errors: [ {
             message: 'DoWhileStatement should not span multiple lines.',
-            type: 'DoWhileStatement'
-         } ]
+            type: 'DoWhileStatement',
+         } ],
       },
       {
          code: invalidForIn,
          errors: [ {
             message: 'ForInStatement should not span multiple lines.',
-            type: 'ForInStatement'
-         } ]
+            type: 'ForInStatement',
+         } ],
       },
-   ]
+   ],
 });

--- a/tests/lib/rules/no-multiline-var-declarations.test.js
+++ b/tests/lib/rules/no-multiline-var-declarations.test.js
@@ -55,15 +55,15 @@ ruleTester.run('no-multiline-var-declaration', rule, {
          code: invalidExample,
          errors: [ {
             message: 'Variable declaration for myArray should not span multiple lines.',
-            type: 'VariableDeclarator'
-         } ]
+            type: 'VariableDeclarator',
+         } ],
       },
       {
          code: invalidExample2,
          errors: [ {
             message: 'Variable declaration for myObj should not span multiple lines.',
-            type: 'VariableDeclarator'
-         } ]
+            type: 'VariableDeclarator',
+         } ],
       },
-   ]
+   ],
 });

--- a/tests/lib/rules/no-multiple-func-decl.test.js
+++ b/tests/lib/rules/no-multiple-func-decl.test.js
@@ -26,11 +26,11 @@ validExample = formatCode(
    'var onFulfill, onReject;',
    '',
    'onFulfill = function(val) {',
-      'console.log(val);',
+   '   console.log(val);',
    '};',
    '',
    'onReject = function(err) {',
-      'console.log(err);',
+   '   console.log(err);',
    '};',
    '',
    'promise.then(onFulfill, onReject);'

--- a/tests/lib/rules/no-multiple-func-decl.test.js
+++ b/tests/lib/rules/no-multiple-func-decl.test.js
@@ -43,7 +43,7 @@ validExample = formatCode(
 
 ruleTester.run('no-multiple-inline-functions', noMultipleFunctionDeclaration, {
    valid: [
-      validExample
+      validExample,
    ],
    invalid: [
       {
@@ -51,9 +51,9 @@ ruleTester.run('no-multiple-inline-functions', noMultipleFunctionDeclaration, {
          errors: [
             {
                message: 'Too many function declarations used as arguments',
-               type: 'FunctionExpression'
-            }
-         ]
-      }
-   ]
+               type: 'FunctionExpression',
+            },
+         ],
+      },
+   ],
 });

--- a/tests/lib/rules/uninitialized-last.test.js
+++ b/tests/lib/rules/uninitialized-last.test.js
@@ -47,21 +47,21 @@ ruleTester.run('uninitialized-last', rule, {
          errors: [
             {
                message: 'Uninitialized variables should come last in the declaration.',
-               type: 'VariableDeclaration'
+               type: 'VariableDeclaration',
             },
             {
                message: 'Uninitialized variables should come last in the declaration.',
-               type: 'VariableDeclaration'
+               type: 'VariableDeclaration',
             },
             {
                message: 'Uninitialized variables should come last in the declaration.',
-               type: 'VariableDeclaration'
+               type: 'VariableDeclaration',
             },
             {
                message: 'Uninitialized variables should come last in the declaration.',
-               type: 'VariableDeclaration'
+               type: 'VariableDeclaration',
             },
          ],
       },
-   ]
+   ],
 });


### PR DESCRIPTION
After adding the new rules to eslint-config-silvermine, we had some errors in the codebase.  This PR is to fix them.

The first simply ran eslint --fix to add dangling commas where needed.
The second is call indentation errors that were not caught with the previous rule.