### PR TITLE
Ensure npm install in is Travis is >= 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
    - '4.5'
+before_install:
+   - if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi
 before_script:
    - npm install -g grunt
 script:


### PR DESCRIPTION
ESLint was unable to find eslint-plugin-silvermine in npm on Travis.

Updating npm to version 3 or above fixes the issue.