### PR TITLE
Fix bugs in fluent-chaining and call-indentation

### DIFF
--- a/lib/rules/call-indentation.js
+++ b/lib/rules/call-indentation.js
@@ -110,7 +110,7 @@ module.exports = function(context) {
             if (prevArg && prevArg.loc.end.line !== arg.loc.start.line) {
                context.report({
                   node: arg,
-                  loc: arg.loc.start.line,
+                  loc: arg.loc.start,
                   message: MSG_ARG_ON_SAME_LINE,
                });
             }

--- a/lib/rules/fluent-chaining.js
+++ b/lib/rules/fluent-chaining.js
@@ -84,9 +84,12 @@ module.exports = {
          // of lines of the expression or we will not be able to put comments between calls
          if (node.property.leadingComments) {
             _.each(node.property.leadingComments, function(comment) {
-               var commentLines = comment.loc.start.line - comment.loc.end.line + 1;
+               var commentLines = comment.loc.end.line - comment.loc.start.line + 1;
 
-               numberOfLines = numberOfLines - commentLines;
+               // make sure the comment is not on the ending line of the previous call
+               if (comment.loc.start.line > node.object.loc.end.line) {
+                  numberOfLines = numberOfLines - commentLines;
+               }
             });
          }
 

--- a/tests/lib/rules/fluent-chaining.valid.js
+++ b/tests/lib/rules/fluent-chaining.valid.js
@@ -95,3 +95,22 @@ aPromise
    .catch(function(err) {
       return err;
    });
+
+aPromise
+   .then(function(val) {
+      return val;
+   })
+   .then(namedFunction) //comment on same line
+   .catch(function(err) {
+      return err;
+   });
+
+aPromise
+   .then(function(val) {
+      return val;
+   })
+   .then(namedFunction) //comment on same line
+   // comment on new line
+   .catch(function(err) {
+      return err;
+   });


### PR DESCRIPTION
When running the new plugin against our repos, I found 2 bugs in the new code. 

1. The fluent-chaining rule was giving errors when there was a comment on the previous method expression's closing line. It was subtracting one too many lines from the line count.
2. One of the checks in the call-indentation rule was not showing the correct location. The location in the reporter was being set to a line and not a location object.

These 2 commits fix those problems.