### PR TITLE
Fix array-indentation rule to add new line checks

### DIFF
--- a/lib/rules/array-indentation.js
+++ b/lib/rules/array-indentation.js
@@ -25,6 +25,20 @@ module.exports = function(context) {
             message: 'Array expressions must begin and end with the same indentation',
          });
       }
+
+      if (node.elements.length > 0 && node.elements[0].loc.start.line === node.loc.start.line) {
+         context.report({
+            node: node,
+            message: 'The first element in multiline array expressions must be on a new line',
+         });
+      }
+
+      if (node.elements.length > 0 && node.elements[node.elements.length - 1].loc.start.line === node.loc.end.line) {
+         context.report({
+            node: node,
+            message: 'The closing parenthesis in multiline array expressions must be on a new line',
+         });
+      }
    }
 
    //--------------------------------------------------------------------------

--- a/tests/lib/rules/array-indentation.test.js
+++ b/tests/lib/rules/array-indentation.test.js
@@ -14,10 +14,16 @@ var rule = require('../../../lib/rules/array-indentation'),
     invalidExample, validExample1, validExample2;
 
 invalidExample = formatCode(
-   'var a;',
+   'var a, b, c;',
    '',
    'a = [',
-   '   3, 4];'
+   '   3, 4];',
+   'b = [ 3,',
+   '   4,',
+   '];',
+   'c = [',
+   '   3,',
+   '4,];'
 );
 
 validExample1 = formatCode(
@@ -50,10 +56,24 @@ ruleTester.run('array-indentation', rule, {
    invalid: [
       {
          code: invalidExample,
-         errors: [ {
-            message: 'Array expressions must begin and end with the same indentation',
-            type: 'ArrayExpression',
-         } ],
+         errors: [
+            {
+               message: 'Array expressions must begin and end with the same indentation',
+               type: 'ArrayExpression',
+            },
+            {
+               message: 'The closing parenthesis in multiline array expressions must be on a new line',
+               type: 'ArrayExpression',
+            },
+            {
+               message: 'The first element in multiline array expressions must be on a new line',
+               type: 'ArrayExpression',
+            },
+            {
+               message: 'The closing parenthesis in multiline array expressions must be on a new line',
+               type: 'ArrayExpression',
+            },
+         ],
       },
    ],
 });


### PR DESCRIPTION
The array-indentation rule will now check that the first
element in multi-line arrays starts on a new line and the
closing parenthesis is on a new line.