### PR TITLE
Update custom fork of indent rule to the new v5 rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,5 +2,13 @@
    "env": {
       "node": true
    },
-   "extends": "@silvermine/eslint-config/node"
+   "extends": "@silvermine/eslint-config/node",
+
+   "rules": {
+      "prefer-template": "off",
+      "padding-line-between-statements": [
+         "error",
+         { "blankLine": "any", "prev": [ "*" ], "next": "return" }
+      ]
+   }
 }

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -1,181 +1,204 @@
 /**
- * @fileoverview This rule sets a specific indentation style and width for your code
- *
- * @author Teddy Katz
- * @author Vitaly Puzrin
- * @author Gyandeep Singh
- */
+* Forked from: https://github.com/eslint/eslint/blob/v5.10.0/lib/rules/indent.js
+* This modification adds the `VariableDeclaratorOffset` configuration variable
+* that allows specifying how many spaces a multi-line variable declaration should
+* be offset from the normal indentation level. For example:
+*
+* var something,
+*     anotherSomething,
+*     somethingElse;
+*
+* The multi-line variable declaration is indented 4 spaces from the normal indentation
+* level, so VariableDeclaratorOffset should be set to '1' (i.e. indent of 3, offset adds
+* 1, total indent 4).  es6 const declarations would need an offset of 3 (indent of 3,
+* offset adds 3, total indent 6) to line up.
+*
+* Example configuration: "silvermine/indent":
+* [
+*    "error",
+*    3,
+*    {
+*       "VariableDeclaratorOffset": { "var": 1, "let": 1, "const": 3 },
+*       "SwitchCase": 1
+*    }
+* ]
+*
+*/
 
-"use strict";
+'use strict';
 
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 // Requirements
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 
-const lodash = require("lodash");
-const astUtils = require("../util/ast-utils");
-const createTree = require("functional-red-black-tree");
+const lodash = require('lodash');
 
-//------------------------------------------------------------------------------
+const astUtils = require('eslint/lib/util/ast-utils');
+
+const createTree = require('functional-red-black-tree');
+
+// ------------------------------------------------------------------------------
 // Rule Definition
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 
 const KNOWN_NODES = new Set([
-    "AssignmentExpression",
-    "AssignmentPattern",
-    "ArrayExpression",
-    "ArrayPattern",
-    "ArrowFunctionExpression",
-    "AwaitExpression",
-    "BlockStatement",
-    "BinaryExpression",
-    "BreakStatement",
-    "CallExpression",
-    "CatchClause",
-    "ClassBody",
-    "ClassDeclaration",
-    "ClassExpression",
-    "ConditionalExpression",
-    "ContinueStatement",
-    "DoWhileStatement",
-    "DebuggerStatement",
-    "EmptyStatement",
-    "ExperimentalRestProperty",
-    "ExperimentalSpreadProperty",
-    "ExpressionStatement",
-    "ForStatement",
-    "ForInStatement",
-    "ForOfStatement",
-    "FunctionDeclaration",
-    "FunctionExpression",
-    "Identifier",
-    "IfStatement",
-    "Literal",
-    "LabeledStatement",
-    "LogicalExpression",
-    "MemberExpression",
-    "MetaProperty",
-    "MethodDefinition",
-    "NewExpression",
-    "ObjectExpression",
-    "ObjectPattern",
-    "Program",
-    "Property",
-    "RestElement",
-    "ReturnStatement",
-    "SequenceExpression",
-    "SpreadElement",
-    "Super",
-    "SwitchCase",
-    "SwitchStatement",
-    "TaggedTemplateExpression",
-    "TemplateElement",
-    "TemplateLiteral",
-    "ThisExpression",
-    "ThrowStatement",
-    "TryStatement",
-    "UnaryExpression",
-    "UpdateExpression",
-    "VariableDeclaration",
-    "VariableDeclarator",
-    "WhileStatement",
-    "WithStatement",
-    "YieldExpression",
-    "JSXIdentifier",
-    "JSXNamespacedName",
-    "JSXMemberExpression",
-    "JSXEmptyExpression",
-    "JSXExpressionContainer",
-    "JSXElement",
-    "JSXClosingElement",
-    "JSXOpeningElement",
-    "JSXAttribute",
-    "JSXSpreadAttribute",
-    "JSXText",
-    "ExportDefaultDeclaration",
-    "ExportNamedDeclaration",
-    "ExportAllDeclaration",
-    "ExportSpecifier",
-    "ImportDeclaration",
-    "ImportSpecifier",
-    "ImportDefaultSpecifier",
-    "ImportNamespaceSpecifier"
+   'AssignmentExpression',
+   'AssignmentPattern',
+   'ArrayExpression',
+   'ArrayPattern',
+   'ArrowFunctionExpression',
+   'AwaitExpression',
+   'BlockStatement',
+   'BinaryExpression',
+   'BreakStatement',
+   'CallExpression',
+   'CatchClause',
+   'ClassBody',
+   'ClassDeclaration',
+   'ClassExpression',
+   'ConditionalExpression',
+   'ContinueStatement',
+   'DoWhileStatement',
+   'DebuggerStatement',
+   'EmptyStatement',
+   'ExperimentalRestProperty',
+   'ExperimentalSpreadProperty',
+   'ExpressionStatement',
+   'ForStatement',
+   'ForInStatement',
+   'ForOfStatement',
+   'FunctionDeclaration',
+   'FunctionExpression',
+   'Identifier',
+   'IfStatement',
+   'Literal',
+   'LabeledStatement',
+   'LogicalExpression',
+   'MemberExpression',
+   'MetaProperty',
+   'MethodDefinition',
+   'NewExpression',
+   'ObjectExpression',
+   'ObjectPattern',
+   'Program',
+   'Property',
+   'RestElement',
+   'ReturnStatement',
+   'SequenceExpression',
+   'SpreadElement',
+   'Super',
+   'SwitchCase',
+   'SwitchStatement',
+   'TaggedTemplateExpression',
+   'TemplateElement',
+   'TemplateLiteral',
+   'ThisExpression',
+   'ThrowStatement',
+   'TryStatement',
+   'UnaryExpression',
+   'UpdateExpression',
+   'VariableDeclaration',
+   'VariableDeclarator',
+   'WhileStatement',
+   'WithStatement',
+   'YieldExpression',
+   'JSXIdentifier',
+   'JSXNamespacedName',
+   'JSXMemberExpression',
+   'JSXEmptyExpression',
+   'JSXExpressionContainer',
+   'JSXElement',
+   'JSXClosingElement',
+   'JSXOpeningElement',
+   'JSXAttribute',
+   'JSXSpreadAttribute',
+   'JSXText',
+   'ExportDefaultDeclaration',
+   'ExportNamedDeclaration',
+   'ExportAllDeclaration',
+   'ExportSpecifier',
+   'ImportDeclaration',
+   'ImportSpecifier',
+   'ImportDefaultSpecifier',
+   'ImportNamespaceSpecifier',
 ]);
 
 /*
  * General rule strategy:
- * 1. An OffsetStorage instance stores a map of desired offsets, where each token has a specified offset from another
- *    specified token or to the first column.
- * 2. As the AST is traversed, modify the desired offsets of tokens accordingly. For example, when entering a
- *    BlockStatement, offset all of the tokens in the BlockStatement by 1 indent level from the opening curly
- *    brace of the BlockStatement.
- * 3. After traversing the AST, calculate the expected indentation levels of every token according to the
- *    OffsetStorage container.
- * 4. For each line, compare the expected indentation of the first token to the actual indentation in the file,
- *    and report the token if the two values are not equal.
+ * 1. An OffsetStorage instance stores a map of desired offsets, where each token has a
+ *    specified offset from another specified token or to the first column.
+ * 2. As the AST is traversed, modify the desired offsets of tokens accordingly. For
+ *    example, when entering a BlockStatement, offset all of the tokens in the
+ *    BlockStatement by 1 indent level from the opening curly brace of the BlockStatement.
+ * 3. After traversing the AST, calculate the expected indentation levels of every token
+ *    according to the OffsetStorage container.
+ * 4. For each line, compare the expected indentation of the first token to the actual
+ *    indentation in the file, and report the token if the two values are not equal.
  */
 
 
 /**
- * A mutable balanced binary search tree that stores (key, value) pairs. The keys are numeric, and must be unique.
- * This is intended to be a generic wrapper around a balanced binary search tree library, so that the underlying implementation
- * can easily be swapped out.
+ * A mutable balanced binary search tree that stores (key, value) pairs. The keys are
+ * numeric, and must be unique. This is intended to be a generic wrapper around a balanced
+ * binary search tree library, so that the underlying implementation can easily be swapped
+ * out.
  */
 class BinarySearchTree {
 
-    /**
-     * Creates an empty tree
-     */
-    constructor() {
-        this._rbTree = createTree();
-    }
+   /**
+    * Creates an empty tree
+    */
+   constructor() {
+      this._rbTree = createTree();
+   }
 
-    /**
-     * Inserts an entry into the tree.
-     * @param {number} key The entry's key
-     * @param {*} value The entry's value
-     * @returns {void}
-     */
-    insert(key, value) {
-        const iterator = this._rbTree.find(key);
+   /**
+    * Inserts an entry into the tree.
+    * @param {number} key The entry's key
+    * @param {*} value The entry's value
+    * @returns {void}
+    */
+   insert(key, value) {
+      const iterator = this._rbTree.find(key);
 
-        if (iterator.valid) {
-            this._rbTree = iterator.update(value);
-        } else {
-            this._rbTree = this._rbTree.insert(key, value);
-        }
-    }
+      if (iterator.valid) {
+         this._rbTree = iterator.update(value);
+      } else {
+         this._rbTree = this._rbTree.insert(key, value);
+      }
+   }
 
-    /**
-     * Finds the entry with the largest key less than or equal to the provided key
-     * @param {number} key The provided key
-     * @returns {{key: number, value: *}|null} The found entry, or null if no such entry exists.
-     */
-    findLe(key) {
-        const iterator = this._rbTree.le(key);
+   /**
+    * Finds the entry with the largest key less than or equal to the provided key
+    * @param {number} key The provided key
+    * @returns {{key: number, value: *}|null} The found entry, or null if no such entry
+    * exists.
+    */
+   findLe(key) {
+      const iterator = this._rbTree.le(key);
 
-        return iterator && { key: iterator.key, value: iterator.value };
-    }
+      return iterator && { key: iterator.key, value: iterator.value };
+   }
 
-    /**
-     * Deletes all of the keys in the interval [start, end)
-     * @param {number} start The start of the range
-     * @param {number} end The end of the range
-     * @returns {void}
-     */
-    deleteRange(start, end) {
+   /**
+    * Deletes all of the keys in the interval [start, end)
+    * @param {number} start The start of the range
+    * @param {number} end The end of the range
+    * @returns {void}
+    */
+   deleteRange(start, end) {
 
-        // Exit without traversing the tree if the range has zero size.
-        if (start === end) {
-            return;
-        }
-        const iterator = this._rbTree.ge(start);
+      // Exit without traversing the tree if the range has zero size.
+      if (start === end) {
+         return;
+      }
+      const iterator = this._rbTree.ge(start);
 
-        while (iterator.valid && iterator.key < end) {
-            this._rbTree = this._rbTree.remove(iterator.key);
-            iterator.next();
-        }
-    }
+      while (iterator.valid && iterator.key < end) {
+         this._rbTree = this._rbTree.remove(iterator.key);
+         iterator.next();
+      }
+   }
 }
 
 /**
@@ -183,48 +206,49 @@ class BinarySearchTree {
  */
 class TokenInfo {
 
-    /**
-     * @param {SourceCode} sourceCode A SourceCode object
-     */
-    constructor(sourceCode) {
-        this.sourceCode = sourceCode;
-        this.firstTokensByLineNumber = sourceCode.tokensAndComments.reduce((map, token) => {
-            if (!map.has(token.loc.start.line)) {
-                map.set(token.loc.start.line, token);
-            }
-            if (!map.has(token.loc.end.line) && sourceCode.text.slice(token.range[1] - token.loc.end.column, token.range[1]).trim()) {
-                map.set(token.loc.end.line, token);
-            }
-            return map;
-        }, new Map());
-    }
+   /**
+    * @param {SourceCode} sourceCode A SourceCode object
+    */
+   constructor(sourceCode) {
+      this.sourceCode = sourceCode;
+      this.firstTokensByLineNumber = sourceCode.tokensAndComments.reduce((map, token) => {
+         if (!map.has(token.loc.start.line)) {
+            map.set(token.loc.start.line, token);
+         }
+         if (!map.has(token.loc.end.line) && sourceCode.text.slice(token.range[1] - token.loc.end.column, token.range[1]).trim()) {
+            map.set(token.loc.end.line, token);
+         }
 
-    /**
-     * Gets the first token on a given token's line
-     * @param {Token|ASTNode} token a node or token
-     * @returns {Token} The first token on the given line
-     */
-    getFirstTokenOfLine(token) {
-        return this.firstTokensByLineNumber.get(token.loc.start.line);
-    }
+         return map;
+      }, new Map());
+   }
 
-    /**
-     * Determines whether a token is the first token in its line
-     * @param {Token} token The token
-     * @returns {boolean} `true` if the token is the first on its line
-     */
-    isFirstTokenOfLine(token) {
-        return this.getFirstTokenOfLine(token) === token;
-    }
+   /**
+    * Gets the first token on a given token's line
+    * @param {Token|ASTNode} token a node or token
+    * @returns {Token} The first token on the given line
+    */
+   getFirstTokenOfLine(token) {
+      return this.firstTokensByLineNumber.get(token.loc.start.line);
+   }
 
-    /**
-     * Get the actual indent of a token
-     * @param {Token} token Token to examine. This should be the first token on its line.
-     * @returns {string} The indentation characters that precede the token
-     */
-    getTokenIndent(token) {
-        return this.sourceCode.text.slice(token.range[0] - token.loc.start.column, token.range[0]);
-    }
+   /**
+    * Determines whether a token is the first token in its line
+    * @param {Token} token The token
+    * @returns {boolean} `true` if the token is the first on its line
+    */
+   isFirstTokenOfLine(token) {
+      return this.getFirstTokenOfLine(token) === token;
+   }
+
+   /**
+    * Get the actual indent of a token
+    * @param {Token} token Token to examine. This should be the first token on its line.
+    * @returns {string} The indentation characters that precede the token
+    */
+   getTokenIndent(token) {
+      return this.sourceCode.text.slice(token.range[0] - token.loc.start.column, token.range[0]);
+   }
 }
 
 /**
@@ -232,1366 +256,1471 @@ class TokenInfo {
  */
 class OffsetStorage {
 
-    /**
-     * @param {TokenInfo} tokenInfo a TokenInfo instance
-     * @param {number} indentSize The desired size of each indentation level
-     * @param {string} indentType The indentation character
-     */
-    constructor(tokenInfo, indentSize, indentType) {
-        this._tokenInfo = tokenInfo;
-        this._indentSize = indentSize;
-        this._indentType = indentType;
+   /**
+    * @param {TokenInfo} tokenInfo a TokenInfo instance
+    * @param {number} indentSize The desired size of each indentation level
+    * @param {string} indentType The indentation character
+    */
+   constructor(tokenInfo, indentSize, indentType) {
+      this._tokenInfo = tokenInfo;
+      this._indentSize = indentSize;
+      this._indentType = indentType;
 
-        this._tree = new BinarySearchTree();
-        this._tree.insert(0, { offset: 0, from: null, force: false });
+      this._tree = new BinarySearchTree();
+      this._tree.insert(0, { offset: 0, from: null, force: false });
 
-        this._lockedFirstTokens = new WeakMap();
-        this._desiredIndentCache = new WeakMap();
-        this._ignoredTokens = new WeakSet();
-    }
+      this._lockedFirstTokens = new WeakMap();
+      this._desiredIndentCache = new WeakMap();
+      this._ignoredTokens = new WeakSet();
+   }
 
-    _getOffsetDescriptor(token) {
-        return this._tree.findLe(token.range[0]).value;
-    }
+   _getOffsetDescriptor(token) {
+      return this._tree.findLe(token.range[0]).value;
+   }
 
-    /**
-     * Sets the offset column of token B to match the offset column of token A.
-     * **WARNING**: This matches a *column*, even if baseToken is not the first token on its line. In
-     * most cases, `setDesiredOffset` should be used instead.
-     * @param {Token} baseToken The first token
-     * @param {Token} offsetToken The second token, whose offset should be matched to the first token
-     * @returns {void}
-     */
-    matchOffsetOf(baseToken, offsetToken) {
+   /**
+    * Sets the offset column of token B to match the offset column of token A.
+    * **WARNING**: This matches a *column*, even if baseToken is not the first token on
+    * its line. In most cases, `setDesiredOffset` should be used instead.
+    * @param {Token} baseToken The first token
+    * @param {Token} offsetToken The second token, whose offset should be matched to the
+    *                            first token
+    * @returns {void}
+    */
+   matchOffsetOf(baseToken, offsetToken) {
 
-        /*
-         * lockedFirstTokens is a map from a token whose indentation is controlled by the "first" option to
-         * the token that it depends on. For example, with the `ArrayExpression: first` option, the first
-         * token of each element in the array after the first will be mapped to the first token of the first
-         * element. The desired indentation of each of these tokens is computed based on the desired indentation
-         * of the "first" element, rather than through the normal offset mechanism.
-         */
-        this._lockedFirstTokens.set(offsetToken, baseToken);
-    }
+      /*
+       * lockedFirstTokens is a map from a token whose indentation is controlled by the
+       * "first" option to the token that it depends on. For example, with the
+       * `ArrayExpression: first` option, the first token of each element in the array
+       * after the first will be mapped to the first token of the first element. The
+       * desired indentation of each of these tokens is computed based on the desired
+       * indentation of the "first" element, rather than through the normal offset
+       * mechanism.
+       */
+      this._lockedFirstTokens.set(offsetToken, baseToken);
+   }
 
-    /**
-     * Sets the desired offset of a token.
-     *
-     * This uses a line-based offset collapsing behavior to handle tokens on the same line.
-     * For example, consider the following two cases:
-     *
-     * (
-     *     [
-     *         bar
-     *     ]
-     * )
-     *
-     * ([
-     *     bar
-     * ])
-     *
-     * Based on the first case, it's clear that the `bar` token needs to have an offset of 1 indent level (4 spaces) from
-     * the `[` token, and the `[` token has to have an offset of 1 indent level from the `(` token. Since the `(` token is
-     * the first on its line (with an indent of 0 spaces), the `bar` token needs to be offset by 2 indent levels (8 spaces)
-     * from the start of its line.
-     *
-     * However, in the second case `bar` should only be indented by 4 spaces. This is because the offset of 1 indent level
-     * between the `(` and the `[` tokens gets "collapsed" because the two tokens are on the same line. As a result, the
-     * `(` token is mapped to the `[` token with an offset of 0, and the rule correctly decides that `bar` should be indented
-     * by 1 indent level from the start of the line.
-     *
-     * This is useful because rule listeners can usually just call `setDesiredOffset` for all the tokens in the node,
-     * without needing to check which lines those tokens are on.
-     *
-     * Note that since collapsing only occurs when two tokens are on the same line, there are a few cases where non-intuitive
-     * behavior can occur. For example, consider the following cases:
-     *
-     * foo(
-     * ).
-     *     bar(
-     *         baz
-     *     )
-     *
-     * foo(
-     * ).bar(
-     *     baz
-     * )
-     *
-     * Based on the first example, it would seem that `bar` should be offset by 1 indent level from `foo`, and `baz`
-     * should be offset by 1 indent level from `bar`. However, this is not correct, because it would result in `baz`
-     * being indented by 2 indent levels in the second case (since `foo`, `bar`, and `baz` are all on separate lines, no
-     * collapsing would occur).
-     *
-     * Instead, the correct way would be to offset `baz` by 1 level from `bar`, offset `bar` by 1 level from the `)`, and
-     * offset the `)` by 0 levels from `foo`. This ensures that the offset between `bar` and the `)` are correctly collapsed
-     * in the second case.
-     *
-     * @param {Token} token The token
-     * @param {Token} fromToken The token that `token` should be offset from
-     * @param {number} offset The desired indent level
-     * @returns {void}
-     */
-    setDesiredOffset(token, fromToken, offset) {
-        return this.setDesiredOffsets(token.range, fromToken, offset);
-    }
+   /**
+    * Sets the desired offset of a token.
+    *
+    * This uses a line-based offset collapsing behavior to handle tokens on the same
+    * line.
+    * For example, consider the following two cases:
+    *
+    * (
+    *     [
+    *         bar
+    *     ]
+    * )
+    *
+    * ([
+    *     bar
+    * ])
+    *
+    * Based on the first case, it's clear that the `bar` token needs to have an offset of
+    * 1 indent level (4 spaces) from the `[` token, and the `[` token has to have an
+    * offset of 1 indent level from the `(` token. Since the `(` token is the first on
+    * its line (with an indent of 0 spaces), the `bar` token needs to be offset by 2
+    * indent levels (8 spaces) from the start of its line.
+    *
+    * However, in the second case `bar` should only be indented by 4 spaces. This is
+    * because the offset of 1 indent level between the `(` and the `[` tokens gets
+    * "collapsed" because the two tokens are on the same line. As a result, the `(` token
+    * is mapped to the `[` token with an offset of 0, and the rule correctly decides that
+    * `bar` should be indented by 1 indent level from the start of the line.
+    *
+    * This is useful because rule listeners can usually just call `setDesiredOffset` for
+    * all the tokens in the node, without needing to check which lines those tokens are
+    * on.
+    *
+    * Note that since collapsing only occurs when two tokens are on the same line, there
+    * are a few cases where non-intuitive behavior can occur. For example, consider the
+    * following cases:
+    *
+    * foo(
+    * ).
+    *     bar(
+    *         baz
+    *     )
+    *
+    * foo(
+    * ).bar(
+    *     baz
+    * )
+    *
+    * Based on the first example, it would seem that `bar` should be offset by 1 indent
+    * level from `foo`, and `baz` should be offset by 1 indent level from `bar`. However,
+    * this is not correct, because it would result in `baz` being indented by 2 indent
+    * levels in the second case (since `foo`, `bar`, and `baz` are all on separate lines,
+    * no collapsing would occur).
+    *
+    * Instead, the correct way would be to offset `baz` by 1 level from `bar`, offset
+    * `bar` by 1 level from the `)`, and offset the `)` by 0 levels from `foo`. This
+    * ensures that the offset between `bar` and the `)` are correctly collapsed in the
+    * second case.
+    *
+    * @param {Token} token The token
+    * @param {Token} fromToken The token that `token` should be offset from
+    * @param {number} offset The desired indent level
+    * @returns {void}
+    */
+   setDesiredOffset(token, fromToken, offset) {
+      return this.setDesiredOffsets(token.range, fromToken, offset);
+   }
 
-    /**
-     * Sets the desired offset of all tokens in a range
-     * It's common for node listeners in this file to need to apply the same offset to a large, contiguous range of tokens.
-     * Moreover, the offset of any given token is usually updated multiple times (roughly once for each node that contains
-     * it). This means that the offset of each token is updated O(AST depth) times.
-     * It would not be performant to store and update the offsets for each token independently, because the rule would end
-     * up having a time complexity of O(number of tokens * AST depth), which is quite slow for large files.
-     *
-     * Instead, the offset tree is represented as a collection of contiguous offset ranges in a file. For example, the following
-     * list could represent the state of the offset tree at a given point:
-     *
-     * * Tokens starting in the interval [0, 15) are aligned with the beginning of the file
-     * * Tokens starting in the interval [15, 30) are offset by 1 indent level from the `bar` token
-     * * Tokens starting in the interval [30, 43) are offset by 1 indent level from the `foo` token
-     * * Tokens starting in the interval [43, 820) are offset by 2 indent levels from the `bar` token
-     * * Tokens starting in the interval [820, ∞) are offset by 1 indent level from the `baz` token
-     *
-     * The `setDesiredOffsets` methods inserts ranges like the ones above. The third line above would be inserted by using:
-     * `setDesiredOffsets([30, 43], fooToken, 1);`
-     *
-     * @param {[number, number]} range A [start, end] pair. All tokens with range[0] <= token.start < range[1] will have the offset applied.
-     * @param {Token} fromToken The token that this is offset from
-     * @param {number} offset The desired indent level
-     * @param {boolean} force `true` if this offset should not use the normal collapsing behavior. This should almost always be false.
-     * @returns {void}
-     */
-    setDesiredOffsets(range, fromToken, offset, force) {
+   /**
+    * Sets the desired offset of all tokens in a range
+    * It's common for node listeners in this file to need to apply the same offset to a
+    * large, contiguous range of tokens.  Moreover, the offset of any given token is
+    * usually updated multiple times (roughly once for each node that contains it). This
+    * means that the offset of each token is updated O(AST depth) times.
+    * It would not be performant to store and update the offsets for each token
+    * independently, because the rule would end up having a time complexity of O(number
+    * of tokens * AST depth), which is quite slow for large files.
+    *
+    * Instead, the offset tree is represented as a collection of contiguous offset ranges
+    * in a file. For example, the following list could represent the state of the offset
+    * tree at a given point:
+    *
+    * * Tokens starting in the interval [0, 15) are aligned with the beginning of the
+    *   file
+    * * Tokens starting in the interval [15, 30) are offset by 1 indent level from the
+    *   `bar` token
+    * * Tokens starting in the interval [30, 43) are offset by 1 indent level from the
+    *   `foo` token
+    * * Tokens starting in the interval [43, 820) are offset by 2 indent levels from the
+    *   `bar` token
+    * * Tokens starting in the interval [820, ∞) are offset by 1 indent
+    * level from the `baz` token
+    *
+    * The `setDesiredOffsets` methods inserts ranges like the ones above. The third line
+    * above would be inserted by using: `setDesiredOffsets([30, 43], fooToken, 1);`
+    *
+    * @param {[number, number]} range A [start, end] pair. All tokens with range[0] <=
+    *                                 token.start < range[1] will have the offset
+    *                                 applied.
+    * @param {Token} fromToken The token that this is offset from
+    * @param {number} offset The desired indent level
+    * @param {boolean} force `true` if this offset should not use the normal collapsing
+    *                        behavior. This should almost always be false.
+    * @returns {void}
+    */
+   setDesiredOffsets(range, fromToken, offset, force) {
 
-        /*
-         * Offset ranges are stored as a collection of nodes, where each node maps a numeric key to an offset
-         * descriptor. The tree for the example above would have the following nodes:
-         *
-         * * key: 0, value: { offset: 0, from: null }
-         * * key: 15, value: { offset: 1, from: barToken }
-         * * key: 30, value: { offset: 1, from: fooToken }
-         * * key: 43, value: { offset: 2, from: barToken }
-         * * key: 820, value: { offset: 1, from: bazToken }
-         *
-         * To find the offset descriptor for any given token, one needs to find the node with the largest key
-         * which is <= token.start. To make this operation fast, the nodes are stored in a balanced binary
-         * search tree indexed by key.
-         */
+      /*
+       * Offset ranges are stored as a collection of nodes, where each node maps a
+       * numeric key to an offset descriptor. The tree for the example above would have
+       * the following nodes:
+       *
+       * * key: 0, value: { offset: 0, from: null }
+       * * key: 15, value: { offset: 1, from: barToken }
+       * * key: 30, value: { offset: 1, from: fooToken }
+       * * key: 43, value: { offset: 2, from: barToken }
+       * * key: 820, value: { offset: 1, from: bazToken }
+       *
+       * To find the offset descriptor for any given token, one needs to find the node
+       * with the largest key which is <= token.start. To make this operation fast, the
+       * nodes are stored in a balanced binary search tree indexed by key.
+       */
+      const descriptorToInsert = { offset, from: fromToken, force };
 
-        const descriptorToInsert = { offset, from: fromToken, force };
+      const descriptorAfterRange = this._tree.findLe(range[1]).value;
 
-        const descriptorAfterRange = this._tree.findLe(range[1]).value;
+      const fromTokenIsInRange = fromToken && fromToken.range[0] >= range[0] && fromToken.range[1] <= range[1];
 
-        const fromTokenIsInRange = fromToken && fromToken.range[0] >= range[0] && fromToken.range[1] <= range[1];
-        const fromTokenDescriptor = fromTokenIsInRange && this._getOffsetDescriptor(fromToken);
+      const fromTokenDescriptor = fromTokenIsInRange && this._getOffsetDescriptor(fromToken);
 
-        // First, remove any existing nodes in the range from the tree.
-        this._tree.deleteRange(range[0] + 1, range[1]);
+      // First, remove any existing nodes in the range from the tree.
+      this._tree.deleteRange(range[0] + 1, range[1]);
 
-        // Insert a new node into the tree for this range
-        this._tree.insert(range[0], descriptorToInsert);
+      // Insert a new node into the tree for this range
+      this._tree.insert(range[0], descriptorToInsert);
 
-        /*
-         * To avoid circular offset dependencies, keep the `fromToken` token mapped to whatever it was mapped to previously,
-         * even if it's in the current range.
-         */
-        if (fromTokenIsInRange) {
-            this._tree.insert(fromToken.range[0], fromTokenDescriptor);
-            this._tree.insert(fromToken.range[1], descriptorToInsert);
-        }
+      /*
+       * To avoid circular offset dependencies, keep the `fromToken` token mapped to
+       * whatever it was mapped to previously, even if it's in the current range.
+       */
+      if (fromTokenIsInRange) {
+         this._tree.insert(fromToken.range[0], fromTokenDescriptor);
+         this._tree.insert(fromToken.range[1], descriptorToInsert);
+      }
 
-        /*
-         * To avoid modifying the offset of tokens after the range, insert another node to keep the offset of the following
-         * tokens the same as it was before.
-         */
-        this._tree.insert(range[1], descriptorAfterRange);
-    }
+      /*
+       * To avoid modifying the offset of tokens after the range, insert another node to
+       * keep the offset of the following tokens the same as it was before.
+       */
+      this._tree.insert(range[1], descriptorAfterRange);
+   }
 
-    /**
-     * Gets the desired indent of a token
-     * @param {Token} token The token
-     * @returns {string} The desired indent of the token
-     */
-    getDesiredIndent(token) {
-        if (!this._desiredIndentCache.has(token)) {
+   /**
+    * Gets the desired indent of a token
+    * @param {Token} token The token
+    * @returns {string} The desired indent of the token
+    */
+   getDesiredIndent(token) {
+      if (!this._desiredIndentCache.has(token)) {
 
-            if (this._ignoredTokens.has(token)) {
+         if (this._ignoredTokens.has(token)) {
 
-                /*
-                 * If the token is ignored, use the actual indent of the token as the desired indent.
-                 * This ensures that no errors are reported for this token.
-                 */
-                this._desiredIndentCache.set(
-                    token,
-                    this._tokenInfo.getTokenIndent(token)
-                );
-            } else if (this._lockedFirstTokens.has(token)) {
-                const firstToken = this._lockedFirstTokens.get(token);
+            /*
+             * If the token is ignored, use the actual indent of the token as the
+             * desired indent.
+             * This ensures that no errors are reported for this token.
+             */
+            this._desiredIndentCache.set(token, this._tokenInfo.getTokenIndent(token));
+         } else if (this._lockedFirstTokens.has(token)) {
+            const firstToken = this._lockedFirstTokens.get(token);
 
-                this._desiredIndentCache.set(
-                    token,
+            this._desiredIndentCache.set(
+               token,
 
-                    // (indentation for the first element's line)
-                    this.getDesiredIndent(this._tokenInfo.getFirstTokenOfLine(firstToken)) +
+               // (indentation for the first element's line)
+               this.getDesiredIndent(this._tokenInfo.getFirstTokenOfLine(firstToken)) +
 
-                        // (space between the start of the first element's line and the first element)
-                        this._indentType.repeat(firstToken.loc.start.column - this._tokenInfo.getFirstTokenOfLine(firstToken).loc.start.column)
-                );
-            } else {
-                const offsetInfo = this._getOffsetDescriptor(token);
-                const offset = (
+               // (space between the start of the first element's line and the first
+               // element)
+               this._indentType.repeat(firstToken.loc.start.column - this._tokenInfo.getFirstTokenOfLine(firstToken).loc.start.column)
+            );
+         } else {
+            const offsetInfo = this._getOffsetDescriptor(token);
+
+            const offset = (
                     offsetInfo.from &&
                     offsetInfo.from.loc.start.line === token.loc.start.line &&
                     !/^\s*?\n/.test(token.value) &&
                     !offsetInfo.force
                 ) ? 0 : offsetInfo.offset * this._indentSize;
 
-                this._desiredIndentCache.set(
-                    token,
-                    (offsetInfo.from ? this.getDesiredIndent(offsetInfo.from) : "") + this._indentType.repeat(offset)
-                );
-            }
-        }
-        return this._desiredIndentCache.get(token);
-    }
+            this._desiredIndentCache.set(
+               token,
+               (offsetInfo.from ? this.getDesiredIndent(offsetInfo.from) : '') + this._indentType.repeat(offset)
+            );
+         }
+      }
 
-    /**
-     * Ignores a token, preventing it from being reported.
-     * @param {Token} token The token
-     * @returns {void}
-     */
-    ignoreToken(token) {
-        if (this._tokenInfo.isFirstTokenOfLine(token)) {
-            this._ignoredTokens.add(token);
-        }
-    }
+      return this._desiredIndentCache.get(token);
+   }
 
-    /**
-     * Gets the first token that the given token's indentation is dependent on
-     * @param {Token} token The token
-     * @returns {Token} The token that the given token depends on, or `null` if the given token is at the top level
-     */
-    getFirstDependency(token) {
-        return this._getOffsetDescriptor(token).from;
-    }
+   /**
+    * Ignores a token, preventing it from being reported.
+    * @param {Token} token The token
+    * @returns {void}
+    */
+   ignoreToken(token) {
+      if (this._tokenInfo.isFirstTokenOfLine(token)) {
+         this._ignoredTokens.add(token);
+      }
+   }
+
+   /**
+    * Gets the first token that the given token's indentation is dependent on
+    * @param {Token} token The token
+    * @returns {Token} The token that the given token depends on, or `null` if the given
+    * token is at the top level
+    */
+   getFirstDependency(token) {
+      return this._getOffsetDescriptor(token).from;
+   }
 }
 
 const ELEMENT_LIST_SCHEMA = {
-    oneOf: [
-        {
-            type: "integer",
-            minimum: 0
-        },
-        {
-            enum: ["first", "off"]
-        }
-    ]
+   oneOf: [
+   {
+      type: 'integer',
+      minimum: 0,
+   },
+   {
+      'enum': [ 'first', 'off' ],
+   },
+   ],
 };
 
 module.exports = {
-    meta: {
-        type: "layout",
+   meta: {
+      type: 'layout',
 
-        docs: {
-            description: "enforce consistent indentation",
-            category: "Stylistic Issues",
-            recommended: false,
-            url: "https://eslint.org/docs/rules/indent"
-        },
+      docs: {
+         description: 'enforce consistent indentation',
+         category: 'Stylistic Issues',
+         recommended: false,
+         url: 'https://eslint.org/docs/rules/indent',
+      },
 
-        fixable: "whitespace",
+      fixable: 'whitespace',
 
-        schema: [
-            {
-                oneOf: [
-                    {
-                        enum: ["tab"]
-                    },
-                    {
-                        type: "integer",
-                        minimum: 0
-                    }
-                ]
-            },
-            {
-                type: "object",
-                properties: {
-                    SwitchCase: {
-                        type: "integer",
-                        minimum: 0
-                    },
-                    VariableDeclarator: {
-                        oneOf: [
-                            {
-                                type: "integer",
-                                minimum: 0
-                            },
-                            {
-                                type: "object",
-                                properties: {
-                                    var: {
-                                        type: "integer",
-                                        minimum: 0
-                                    },
-                                    let: {
-                                        type: "integer",
-                                        minimum: 0
-                                    },
-                                    const: {
-                                        type: "integer",
-                                        minimum: 0
-                                    }
-                                },
-                                additionalProperties: false
-                            }
-                        ]
-                    },
-                    outerIIFEBody: {
-                        type: "integer",
-                        minimum: 0
-                    },
-                    MemberExpression: {
-                        oneOf: [
-                            {
-                                type: "integer",
-                                minimum: 0
-                            },
-                            {
-                                enum: ["off"]
-                            }
-                        ]
-                    },
-                    FunctionDeclaration: {
-                        type: "object",
+      schema: [
+         {
+            oneOf: [
+               {
+                  'enum': [ 'tab' ],
+               },
+               {
+                  type: 'integer',
+                  minimum: 0,
+               },
+            ],
+         },
+         {
+            type: 'object',
+            properties: {
+               SwitchCase: {
+                  type: 'integer',
+                  minimum: 0,
+               },
+               VariableDeclarator: {
+                  oneOf: [
+                     {
+                        type: 'number',
+                        minimum: 0,
+                     },
+                     {
+                        type: 'object',
                         properties: {
-                            parameters: ELEMENT_LIST_SCHEMA,
-                            body: {
-                                type: "integer",
-                                minimum: 0
-                            }
+                           'var': {
+                              type: 'number',
+                              minimum: 0,
+                           },
+                           let: {
+                              type: 'number',
+                              minimum: 0,
+                           },
+                           'const': {
+                              type: 'number',
+                              minimum: 0,
+                           },
                         },
-                        additionalProperties: false
-                    },
-                    FunctionExpression: {
-                        type: "object",
-                        properties: {
-                            parameters: ELEMENT_LIST_SCHEMA,
-                            body: {
-                                type: "integer",
-                                minimum: 0
-                            }
-                        },
-                        additionalProperties: false
-                    },
-                    CallExpression: {
-                        type: "object",
-                        properties: {
-                            arguments: ELEMENT_LIST_SCHEMA
-                        },
-                        additionalProperties: false
-                    },
-                    ArrayExpression: ELEMENT_LIST_SCHEMA,
-                    ObjectExpression: ELEMENT_LIST_SCHEMA,
-                    ImportDeclaration: ELEMENT_LIST_SCHEMA,
-                    flatTernaryExpressions: {
-                        type: "boolean"
-                    },
-                    ignoredNodes: {
-                        type: "array",
-                        items: {
-                            type: "string",
-                            not: {
-                                pattern: ":exit$"
-                            }
-                        }
-                    },
-                    ignoreComments: {
-                        type: "boolean"
-                    }
-                },
-                additionalProperties: false
-            }
-        ]
-    },
-
-    create(context) {
-        const DEFAULT_VARIABLE_INDENT = 1;
-        const DEFAULT_PARAMETER_INDENT = 1;
-        const DEFAULT_FUNCTION_BODY_INDENT = 1;
-
-        let indentType = "space";
-        let indentSize = 4;
-        const options = {
-            SwitchCase: 0,
-            VariableDeclarator: {
-                var: DEFAULT_VARIABLE_INDENT,
-                let: DEFAULT_VARIABLE_INDENT,
-                const: DEFAULT_VARIABLE_INDENT
+                        additionalProperties: false,
+                     },
+                  ],
+               },
+               outerIIFEBody: {
+                  type: 'integer',
+                  minimum: 0,
+               },
+               MemberExpression: {
+                  oneOf: [
+                     {
+                        type: 'integer',
+                        minimum: 0,
+                     },
+                     {
+                        'enum': [ 'off' ],
+                     },
+                  ],
+               },
+               FunctionDeclaration: {
+                  type: 'object',
+                  properties: {
+                     parameters: ELEMENT_LIST_SCHEMA,
+                     body: {
+                        type: 'integer',
+                        minimum: 0,
+                     },
+                  },
+                  additionalProperties: false,
+               },
+               FunctionExpression: {
+                  type: 'object',
+                  properties: {
+                     parameters: ELEMENT_LIST_SCHEMA,
+                     body: {
+                        type: 'integer',
+                        minimum: 0,
+                     },
+                  },
+                  additionalProperties: false,
+               },
+               CallExpression: {
+                  type: 'object',
+                  properties: {
+                     arguments: ELEMENT_LIST_SCHEMA,
+                  },
+                  additionalProperties: false,
+               },
+               ArrayExpression: ELEMENT_LIST_SCHEMA,
+               ObjectExpression: ELEMENT_LIST_SCHEMA,
+               ImportDeclaration: ELEMENT_LIST_SCHEMA,
+               flatTernaryExpressions: {
+                  type: 'boolean',
+               },
+               ignoredNodes: {
+                  type: 'array',
+                  items: {
+                     type: 'string',
+                     not: {
+                        pattern: ':exit$',
+                     },
+                  },
+               },
+               ignoreComments: {
+                  type: 'boolean',
+               },
             },
-            outerIIFEBody: 1,
-            FunctionDeclaration: {
-                parameters: DEFAULT_PARAMETER_INDENT,
-                body: DEFAULT_FUNCTION_BODY_INDENT
-            },
-            FunctionExpression: {
-                parameters: DEFAULT_PARAMETER_INDENT,
-                body: DEFAULT_FUNCTION_BODY_INDENT
-            },
-            CallExpression: {
-                arguments: DEFAULT_PARAMETER_INDENT
-            },
-            MemberExpression: 1,
-            ArrayExpression: 1,
-            ObjectExpression: 1,
-            ImportDeclaration: 1,
-            flatTernaryExpressions: false,
-            ignoredNodes: [],
-            ignoreComments: false
-        };
+            additionalProperties: false,
+         },
+      ],
+   },
 
-        if (context.options.length) {
-            if (context.options[0] === "tab") {
-                indentSize = 1;
-                indentType = "tab";
-            } else {
-                indentSize = context.options[0];
-                indentType = "space";
+   create(context) {
+      const DEFAULT_VARIABLE_INDENT = 1,
+            DEFAULT_PARAMETER_INDENT = 1,
+            DEFAULT_FUNCTION_BODY_INDENT = 1;
+
+      let indentType = 'space',
+          indentSize = 4;
+
+      const options = {
+         SwitchCase: 0,
+         VariableDeclarator: {
+            'var': DEFAULT_VARIABLE_INDENT,
+            let: DEFAULT_VARIABLE_INDENT,
+            'const': DEFAULT_VARIABLE_INDENT,
+         },
+         outerIIFEBody: 1,
+         FunctionDeclaration: {
+            parameters: DEFAULT_PARAMETER_INDENT,
+            body: DEFAULT_FUNCTION_BODY_INDENT,
+         },
+         FunctionExpression: {
+            parameters: DEFAULT_PARAMETER_INDENT,
+            body: DEFAULT_FUNCTION_BODY_INDENT,
+         },
+         CallExpression: {
+            arguments: DEFAULT_PARAMETER_INDENT,
+         },
+         MemberExpression: 1,
+         ArrayExpression: 1,
+         ObjectExpression: 1,
+         ImportDeclaration: 1,
+         flatTernaryExpressions: false,
+         ignoredNodes: [],
+         ignoreComments: false,
+      };
+
+      if (context.options.length) {
+         if (context.options[0] === 'tab') {
+            indentSize = 1;
+            indentType = 'tab';
+         } else {
+            indentSize = context.options[0];
+            indentType = 'space';
+         }
+
+         if (context.options[1]) {
+            lodash.merge(options, context.options[1]);
+
+            if (typeof options.VariableDeclarator === 'number') {
+               options.VariableDeclarator = {
+                  'var': options.VariableDeclarator,
+                  let: options.VariableDeclarator,
+                  'const': options.VariableDeclarator,
+               };
             }
+         }
+      }
 
-            if (context.options[1]) {
-                lodash.merge(options, context.options[1]);
+      const sourceCode = context.getSourceCode();
 
-                if (typeof options.VariableDeclarator === "number") {
-                    options.VariableDeclarator = {
-                        var: options.VariableDeclarator,
-                        let: options.VariableDeclarator,
-                        const: options.VariableDeclarator
-                    };
-                }
-            }
-        }
+      const tokenInfo = new TokenInfo(sourceCode);
 
-        const sourceCode = context.getSourceCode();
-        const tokenInfo = new TokenInfo(sourceCode);
-        const offsets = new OffsetStorage(tokenInfo, indentSize, indentType === "space" ? " " : "\t");
-        const parameterParens = new WeakSet();
+      const offsets = new OffsetStorage(tokenInfo, indentSize, indentType === 'space' ? ' ' : '\t');
 
-        /**
-         * Creates an error message for a line, given the expected/actual indentation.
-         * @param {int} expectedAmount The expected amount of indentation characters for this line
-         * @param {int} actualSpaces The actual number of indentation spaces that were found on this line
-         * @param {int} actualTabs The actual number of indentation tabs that were found on this line
-         * @returns {string} An error message for this line
-         */
-        function createErrorMessage(expectedAmount, actualSpaces, actualTabs) {
-            const expectedStatement = `${expectedAmount} ${indentType}${expectedAmount === 1 ? "" : "s"}`; // e.g. "2 tabs"
-            const foundSpacesWord = `space${actualSpaces === 1 ? "" : "s"}`; // e.g. "space"
-            const foundTabsWord = `tab${actualTabs === 1 ? "" : "s"}`; // e.g. "tabs"
-            let foundStatement;
+      const parameterParens = new WeakSet();
 
-            if (actualSpaces > 0) {
+      /**
+       * Creates an error message for a line, given the expected/actual indentation.
+       * @param {int} expectedAmount The expected amount of indentation characters for
+       *                             this line
+       * @param {int} actualSpaces The actual number of indentation spaces that were
+       *                           found on this line
+       * @param {int} actualTabs The actual number of indentation tabs that were found
+       *                         on this line
+       * @returns {string} An error message for this line
+       */
+      function createErrorMessage(expectedAmount, actualSpaces, actualTabs) {
+         const expectedStatement = `${expectedAmount} ${indentType}${expectedAmount === 1 ? '' : 's'}`; // e.g. "2 tabs"
 
-                /*
-                 * Abbreviate the message if the expected indentation is also spaces.
-                 * e.g. 'Expected 4 spaces but found 2' rather than 'Expected 4 spaces but found 2 spaces'
-                 */
-                foundStatement = indentType === "space" ? actualSpaces : `${actualSpaces} ${foundSpacesWord}`;
-            } else if (actualTabs > 0) {
-                foundStatement = indentType === "tab" ? actualTabs : `${actualTabs} ${foundTabsWord}`;
-            } else {
-                foundStatement = "0";
-            }
+         const foundSpacesWord = `space${actualSpaces === 1 ? '' : 's'}`; // e.g. "space"
 
-            return `Expected indentation of ${expectedStatement} but found ${foundStatement}.`;
-        }
+         const foundTabsWord = `tab${actualTabs === 1 ? '' : 's'}`; // e.g. "tabs"
 
-        /**
-         * Reports a given indent violation
-         * @param {Token} token Token violating the indent rule
-         * @param {string} neededIndent Expected indentation string
-         * @returns {void}
-         */
-        function report(token, neededIndent) {
-            const actualIndent = Array.from(tokenInfo.getTokenIndent(token));
-            const numSpaces = actualIndent.filter(char => char === " ").length;
-            const numTabs = actualIndent.filter(char => char === "\t").length;
+         let foundStatement;
 
-            context.report({
-                node: token,
-                message: createErrorMessage(neededIndent.length, numSpaces, numTabs),
-                loc: {
-                    start: { line: token.loc.start.line, column: 0 },
-                    end: { line: token.loc.start.line, column: token.loc.start.column }
-                },
-                fix(fixer) {
-                    const range = [token.range[0] - token.loc.start.column, token.range[0]];
-                    const newText = neededIndent;
-
-                    return fixer.replaceTextRange(range, newText);
-                }
-            });
-        }
-
-        /**
-         * Checks if a token's indentation is correct
-         * @param {Token} token Token to examine
-         * @param {string} desiredIndent Desired indentation of the string
-         * @returns {boolean} `true` if the token's indentation is correct
-         */
-        function validateTokenIndent(token, desiredIndent) {
-            const indentation = tokenInfo.getTokenIndent(token);
-
-            return indentation === desiredIndent ||
-
-                // To avoid conflicts with no-mixed-spaces-and-tabs, don't report mixed spaces and tabs.
-                indentation.includes(" ") && indentation.includes("\t");
-        }
-
-        /**
-         * Check to see if the node is a file level IIFE
-         * @param {ASTNode} node The function node to check.
-         * @returns {boolean} True if the node is the outer IIFE
-         */
-        function isOuterIIFE(node) {
+         if (actualSpaces > 0) {
 
             /*
-             * Verify that the node is an IIFE
+             * Abbreviate the message if the expected indentation is also spaces.
+             * e.g. 'Expected 4 spaces but found 2' rather than 'Expected 4 spaces but
+             * found 2 spaces'
              */
-            if (!node.parent || node.parent.type !== "CallExpression" || node.parent.callee !== node) {
-                return false;
+            foundStatement = indentType === 'space' ? actualSpaces : `${actualSpaces} ${foundSpacesWord}`;
+         } else if (actualTabs > 0) {
+            foundStatement = indentType === 'tab' ? actualTabs : `${actualTabs} ${foundTabsWord}`;
+         } else {
+            foundStatement = '0';
+         }
+
+         return `Expected indentation of ${expectedStatement} but found ${foundStatement}.`;
+      }
+
+      /**
+       * Reports a given indent violation
+       * @param {Token} token Token violating the indent rule
+       * @param {string} neededIndent Expected indentation string
+       * @returns {void}
+       */
+      function report(token, neededIndent) {
+         const actualIndent = Array.from(tokenInfo.getTokenIndent(token));
+
+         const numSpaces = actualIndent.filter((char) => char === ' ').length;
+
+         const numTabs = actualIndent.filter((char) => char === '\t').length;
+
+         context.report({
+            node: token,
+            message: createErrorMessage(neededIndent.length, numSpaces, numTabs),
+            loc: {
+               start: { line: token.loc.start.line, column: 0 },
+               end: { line: token.loc.start.line, column: token.loc.start.column },
+            },
+            fix(fixer) {
+               const range = [ token.range[0] - token.loc.start.column, token.range[0] ];
+
+               const newText = neededIndent;
+
+               return fixer.replaceTextRange(range, newText);
+            },
+         });
+      }
+
+      /**
+       * Checks if a token's indentation is correct
+       * @param {Token} token Token to examine
+       * @param {string} desiredIndent Desired indentation of the string
+       * @returns {boolean} `true` if the token's indentation is correct
+       */
+      function validateTokenIndent(token, desiredIndent) {
+         const indentation = tokenInfo.getTokenIndent(token);
+
+         return indentation === desiredIndent ||
+                // To avoid conflicts with no-mixed-spaces-and-tabs, don't report mixed
+                // spaces and tabs.
+                indentation.includes(' ') && indentation.includes('\t');
+      }
+
+      /**
+       * Check to see if the node is a file level IIFE
+       * @param {ASTNode} node The function node to check.
+       * @returns {boolean} True if the node is the outer IIFE
+       */
+      function isOuterIIFE(node) {
+
+         /*
+          * Verify that the node is an IIFE
+          */
+         if (!node.parent || node.parent.type !== 'CallExpression' || node.parent.callee !== node) {
+            return false;
+         }
+
+         /*
+          * Navigate legal ancestors to determine whether this IIFE is outer.
+          * A "legal ancestor" is an expression or statement that causes the function
+          * to get executed immediately.
+          * For example, `!(function(){})()` is an outer IIFE even though it is
+          * preceded by a ! operator.
+          */
+         let statement = node.parent && node.parent.parent;
+
+         function checkStatement(stmt) {
+            return stmt.type === 'UnaryExpression' && [ '!', '~', '+', '-' ].indexOf(stmt.operator) > -1 ||
+                   stmt.type === 'AssignmentExpression' ||
+                   stmt.type === 'LogicalExpression' ||
+                   stmt.type === 'SequenceExpression' ||
+                   stmt.type === 'VariableDeclarator';
+         }
+
+         while (checkStatement(statement)) {
+            statement = statement.parent;
+         }
+
+         return (statement.type === 'ExpressionStatement' || statement.type === 'VariableDeclaration') &&
+                statement.parent.type === 'Program';
+      }
+
+      /**
+       * Counts the number of linebreaks that follow the last non-whitespace character
+       * in a string
+       * @param {string} string The string to check
+       * @returns {number} The number of JavaScript linebreaks that follow the last
+       * non-whitespace character,
+       * or the total number of linebreaks if the string is all whitespace.
+       */
+      function countTrailingLinebreaks(string) {
+         const trailingWhitespace = string.match(/\s*$/)[0];
+
+         const linebreakMatches = trailingWhitespace.match(astUtils.createGlobalLinebreakMatcher());
+
+         return linebreakMatches === null ? 0 : linebreakMatches.length;
+      }
+
+      /**
+       * Check indentation for lists of elements (arrays, objects, function params)
+       * @param {ASTNode[]} elements List of elements that should be offset
+       * @param {Token} startToken The start token of the list that element should be
+       *                           aligned against, e.g. '['
+       * @param {Token} endToken The end token of the list, e.g. ']'
+       * @param {number|string} offset The amount that the elements should be offset
+       * @returns {void}
+       */
+      function addElementListIndent(elements, startToken, endToken, offset) {
+
+         /**
+          * Gets the first token of a given element, including surrounding parentheses.
+          * @param {ASTNode} element A node in the `elements` list
+          * @returns {Token} The first token of this element
+          */
+         function getFirstToken(element) {
+            let token = sourceCode.getTokenBefore(element);
+
+            while (astUtils.isOpeningParenToken(token) && token !== startToken) {
+               token = sourceCode.getTokenBefore(token);
             }
+
+            return sourceCode.getTokenAfter(token);
+         }
+
+         // Run through all the tokens in the list, and offset them by one indent level
+         // (mainly for comments, other things will end up overridden)
+         offsets.setDesiredOffsets(
+            [ startToken.range[1], endToken.range[0] ],
+            startToken,
+            typeof offset === 'number' ? offset : 1
+         );
+         offsets.setDesiredOffset(endToken, startToken, 0);
+
+         // If the preference is "first" but there is no first element (e.g. sparse arrays
+         // w/ empty first slot), fall back to 1 level.
+         if (offset === 'first' && elements.length && !elements[0]) {
+            return;
+         }
+         elements.forEach((element, index) => {
+            if (!element) {
+
+               // Skip holes in arrays
+               return;
+            }
+            if (offset === 'off') {
+
+               // Ignore the first token of every element if the "off" option is used
+               offsets.ignoreToken(getFirstToken(element));
+            }
+
+            // Offset the following elements correctly relative to the first element
+            if (index === 0) {
+               return;
+            }
+            if (offset === 'first' && tokenInfo.isFirstTokenOfLine(getFirstToken(element))) {
+               offsets.matchOffsetOf(getFirstToken(elements[0]), getFirstToken(element));
+            } else {
+               const previousElement = elements[index - 1],
+                     firstTokenOfPreviousElement = previousElement && getFirstToken(previousElement),
+                     previousElementLastToken = previousElement && sourceCode.getLastToken(previousElement),
+                     prevElEndLine = previousElementLastToken.loc.end.line - countTrailingLinebreaks(previousElementLastToken.value);
+
+               if (previousElement && prevElEndLine > startToken.loc.end.line) {
+                  offsets.setDesiredOffsets([ previousElement.range[1], element.range[1] ], firstTokenOfPreviousElement, 0);
+               }
+            }
+         });
+      }
+
+      /**
+       * Check and decide whether to check for indentation for blockless nodes
+       * Scenarios are for or while statements without braces around them
+       * @param {ASTNode} node node to examine
+       * @returns {void}
+       */
+      function addBlocklessNodeIndent(node) {
+         if (node.type !== 'BlockStatement') {
+            const lastParentToken = sourceCode.getTokenBefore(node, astUtils.isNotOpeningParenToken);
+
+            let firstBodyToken = sourceCode.getFirstToken(node),
+                lastBodyToken = sourceCode.getLastToken(node);
+
+            // eslint-disable-next-line max-len
+            while (astUtils.isOpeningParenToken(sourceCode.getTokenBefore(firstBodyToken)) && astUtils.isClosingParenToken(sourceCode.getTokenAfter(lastBodyToken))) {
+               firstBodyToken = sourceCode.getTokenBefore(firstBodyToken);
+               lastBodyToken = sourceCode.getTokenAfter(lastBodyToken);
+            }
+
+            offsets.setDesiredOffsets([ firstBodyToken.range[0], lastBodyToken.range[1] ], lastParentToken, 1);
 
             /*
-             * Navigate legal ancestors to determine whether this IIFE is outer.
-             * A "legal ancestor" is an expression or statement that causes the function to get executed immediately.
-             * For example, `!(function(){})()` is an outer IIFE even though it is preceded by a ! operator.
+             * For blockless nodes with semicolon-first style, don't indent the semicolon.
+             * e.g.
+             * if (foo) bar()
+             * ; [1, 2, 3].map(foo)
              */
-            let statement = node.parent && node.parent.parent;
+            const lastToken = sourceCode.getLastToken(node);
 
-            while (
-                statement.type === "UnaryExpression" && ["!", "~", "+", "-"].indexOf(statement.operator) > -1 ||
-                statement.type === "AssignmentExpression" ||
-                statement.type === "LogicalExpression" ||
-                statement.type === "SequenceExpression" ||
-                statement.type === "VariableDeclarator"
-            ) {
-                statement = statement.parent;
+            if (node.type !== 'EmptyStatement' && astUtils.isSemicolonToken(lastToken)) {
+               offsets.setDesiredOffset(lastToken, lastParentToken, 0);
+            }
+         }
+      }
+
+      /**
+       * Checks the indentation for nodes that are like function calls (`CallExpression`
+       * and `NewExpression`)
+       * @param {ASTNode} node A CallExpression or NewExpression node
+       * @returns {void}
+       */
+      function addFunctionCallIndent(node) {
+         let openingParen;
+
+         if (node.arguments.length) {
+            openingParen = sourceCode.getFirstTokenBetween(node.callee, node.arguments[0], astUtils.isOpeningParenToken);
+         } else {
+            openingParen = sourceCode.getLastToken(node, 1);
+         }
+         const closingParen = sourceCode.getLastToken(node);
+
+         parameterParens.add(openingParen);
+         parameterParens.add(closingParen);
+         offsets.setDesiredOffset(openingParen, sourceCode.getTokenBefore(openingParen), 0);
+
+         addElementListIndent(node.arguments, openingParen, closingParen, options.CallExpression.arguments);
+      }
+
+      /**
+       * Checks the indentation of parenthesized values, given a list of tokens in a
+       * program
+       * @param {Token[]} tokens A list of tokens
+       * @returns {void}
+       */
+      function addParensIndent(tokens) {
+         const parenStack = [];
+
+         const parenPairs = [];
+
+         tokens.forEach((nextToken) => {
+
+            // Accumulate a list of parenthesis pairs
+            if (astUtils.isOpeningParenToken(nextToken)) {
+               parenStack.push(nextToken);
+            } else if (astUtils.isClosingParenToken(nextToken)) {
+               parenPairs.unshift({ left: parenStack.pop(), right: nextToken });
+            }
+         });
+
+         parenPairs.forEach((pair) => {
+            const leftParen = pair.left;
+
+            const rightParen = pair.right;
+
+            // We only want to handle parens around expressions, so exclude parentheses
+            // that are in function parameters and function call arguments.
+            if (!parameterParens.has(leftParen) && !parameterParens.has(rightParen)) {
+               const parenthesizedTokens = new Set(sourceCode.getTokensBetween(leftParen, rightParen));
+
+               parenthesizedTokens.forEach((token) => {
+                  if (!parenthesizedTokens.has(offsets.getFirstDependency(token))) {
+                     offsets.setDesiredOffset(token, leftParen, 1);
+                  }
+               });
             }
 
-            return (statement.type === "ExpressionStatement" || statement.type === "VariableDeclaration") && statement.parent.type === "Program";
-        }
+            offsets.setDesiredOffset(rightParen, leftParen, 0);
+         });
+      }
 
-        /**
-         * Counts the number of linebreaks that follow the last non-whitespace character in a string
-         * @param {string} string The string to check
-         * @returns {number} The number of JavaScript linebreaks that follow the last non-whitespace character,
-         * or the total number of linebreaks if the string is all whitespace.
-         */
-        function countTrailingLinebreaks(string) {
-            const trailingWhitespace = string.match(/\s*$/)[0];
-            const linebreakMatches = trailingWhitespace.match(astUtils.createGlobalLinebreakMatcher());
+      /**
+       * Ignore all tokens within an unknown node whose offset do not depend
+       * on another token's offset within the unknown node
+       * @param {ASTNode} node Unknown Node
+       * @returns {void}
+       */
+      function ignoreNode(node) {
+         const unknownNodeTokens = new Set(sourceCode.getTokens(node, { includeComments: true }));
 
-            return linebreakMatches === null ? 0 : linebreakMatches.length;
-        }
+         unknownNodeTokens.forEach((token) => {
+            if (!unknownNodeTokens.has(offsets.getFirstDependency(token))) {
+               const firstTokenOfLine = tokenInfo.getFirstTokenOfLine(token);
 
-        /**
-         * Check indentation for lists of elements (arrays, objects, function params)
-         * @param {ASTNode[]} elements List of elements that should be offset
-         * @param {Token} startToken The start token of the list that element should be aligned against, e.g. '['
-         * @param {Token} endToken The end token of the list, e.g. ']'
-         * @param {number|string} offset The amount that the elements should be offset
-         * @returns {void}
-         */
-        function addElementListIndent(elements, startToken, endToken, offset) {
-
-            /**
-             * Gets the first token of a given element, including surrounding parentheses.
-             * @param {ASTNode} element A node in the `elements` list
-             * @returns {Token} The first token of this element
-             */
-            function getFirstToken(element) {
-                let token = sourceCode.getTokenBefore(element);
-
-                while (astUtils.isOpeningParenToken(token) && token !== startToken) {
-                    token = sourceCode.getTokenBefore(token);
-                }
-                return sourceCode.getTokenAfter(token);
+               if (token === firstTokenOfLine) {
+                  offsets.ignoreToken(token);
+               } else {
+                  offsets.setDesiredOffset(token, firstTokenOfLine, 0);
+               }
             }
+         });
+      }
 
-            // Run through all the tokens in the list, and offset them by one indent level (mainly for comments, other things will end up overridden)
-            offsets.setDesiredOffsets(
-                [startToken.range[1], endToken.range[0]],
-                startToken,
-                typeof offset === "number" ? offset : 1
+      /**
+       * Check whether the given token is on the first line of a statement.
+       * @param {Token} token The token to check.
+       * @param {ASTNode} leafNode The expression node that the token belongs directly.
+       * @returns {boolean} `true` if the token is on the first line of a statement.
+       */
+      function isOnFirstLineOfStatement(token, leafNode) {
+         let node = leafNode;
+
+         while (node.parent && !node.parent.type.endsWith('Statement') && !node.parent.type.endsWith('Declaration')) {
+            node = node.parent;
+         }
+         node = node.parent;
+
+         return !node || node.loc.start.line === token.loc.start.line;
+      }
+
+      /**
+       * Check whether there are any blank (whitespace-only) lines between
+       * two tokens on separate lines.
+       * @param {Token} firstToken The first token.
+       * @param {Token} secondToken The second token.
+       * @returns {boolean} `true` if the tokens are on separate lines and
+       *   there exists a blank line between them, `false` otherwise.
+       */
+      function hasBlankLinesBetween(firstToken, secondToken) {
+         const firstTokenLine = firstToken.loc.end.line;
+
+         const secondTokenLine = secondToken.loc.start.line;
+
+         if (firstTokenLine === secondTokenLine || firstTokenLine === secondTokenLine - 1) {
+            return false;
+         }
+
+         for (let line = firstTokenLine + 1; line < secondTokenLine; ++line) {
+            if (!tokenInfo.firstTokensByLineNumber.has(line)) {
+               return true;
+            }
+         }
+
+         return false;
+      }
+
+      const ignoredNodeFirstTokens = new Set();
+
+      const baseOffsetListeners = {
+         'ArrayExpression, ArrayPattern'(node) {
+            const openingBracket = sourceCode.getFirstToken(node),
+                  prevToken = lodash.findLast(node.elements) || openingBracket,
+                  closingBracket = sourceCode.getTokenAfter(prevToken, astUtils.isClosingBracketToken);
+
+            addElementListIndent(node.elements, openingBracket, closingBracket, options.ArrayExpression);
+         },
+
+         'ObjectExpression, ObjectPattern'(node) {
+            const openingCurly = sourceCode.getFirstToken(node);
+
+            const closingCurly = sourceCode.getTokenAfter(
+               node.properties.length ? node.properties[node.properties.length - 1] : openingCurly,
+               astUtils.isClosingBraceToken
             );
-            offsets.setDesiredOffset(endToken, startToken, 0);
 
-            // If the preference is "first" but there is no first element (e.g. sparse arrays w/ empty first slot), fall back to 1 level.
-            if (offset === "first" && elements.length && !elements[0]) {
-                return;
+            addElementListIndent(node.properties, openingCurly, closingCurly, options.ObjectExpression);
+         },
+
+         ArrowFunctionExpression(node) {
+            const firstToken = sourceCode.getFirstToken(node);
+
+            if (astUtils.isOpeningParenToken(firstToken)) {
+               const openingParen = firstToken;
+
+               const closingParen = sourceCode.getTokenBefore(node.body, astUtils.isClosingParenToken);
+
+               parameterParens.add(openingParen);
+               parameterParens.add(closingParen);
+               addElementListIndent(node.params, openingParen, closingParen, options.FunctionExpression.parameters);
             }
-            elements.forEach((element, index) => {
-                if (!element) {
+            addBlocklessNodeIndent(node.body);
+         },
 
-                    // Skip holes in arrays
-                    return;
-                }
-                if (offset === "off") {
+         AssignmentExpression(node) {
+            const operator = sourceCode.getFirstTokenBetween(node.left, node.right, (token) => token.value === node.operator);
 
-                    // Ignore the first token of every element if the "off" option is used
-                    offsets.ignoreToken(getFirstToken(element));
-                }
+            offsets.setDesiredOffsets([ operator.range[0], node.range[1] ], sourceCode.getLastToken(node.left), 1);
+            offsets.ignoreToken(operator);
+            offsets.ignoreToken(sourceCode.getTokenAfter(operator));
+         },
 
-                // Offset the following elements correctly relative to the first element
-                if (index === 0) {
-                    return;
-                }
-                if (offset === "first" && tokenInfo.isFirstTokenOfLine(getFirstToken(element))) {
-                    offsets.matchOffsetOf(getFirstToken(elements[0]), getFirstToken(element));
-                } else {
-                    const previousElement = elements[index - 1];
-                    const firstTokenOfPreviousElement = previousElement && getFirstToken(previousElement);
-                    const previousElementLastToken = previousElement && sourceCode.getLastToken(previousElement);
+         'BinaryExpression, LogicalExpression'(node) {
+            const operator = sourceCode.getFirstTokenBetween(node.left, node.right, (token) => token.value === node.operator);
 
-                    if (
-                        previousElement &&
-                        previousElementLastToken.loc.end.line - countTrailingLinebreaks(previousElementLastToken.value) > startToken.loc.end.line
-                    ) {
-                        offsets.setDesiredOffsets(
-                            [previousElement.range[1], element.range[1]],
-                            firstTokenOfPreviousElement,
-                            0
-                        );
-                    }
-                }
-            });
-        }
+            /*
+             * For backwards compatibility, don't check BinaryExpression indents, e.g.
+             * var foo = bar &&
+             *                   baz;
+             */
+            const tokenAfterOperator = sourceCode.getTokenAfter(operator);
 
-        /**
-         * Check and decide whether to check for indentation for blockless nodes
-         * Scenarios are for or while statements without braces around them
-         * @param {ASTNode} node node to examine
-         * @returns {void}
-         */
-        function addBlocklessNodeIndent(node) {
-            if (node.type !== "BlockStatement") {
-                const lastParentToken = sourceCode.getTokenBefore(node, astUtils.isNotOpeningParenToken);
+            offsets.ignoreToken(operator);
+            offsets.ignoreToken(tokenAfterOperator);
+            offsets.setDesiredOffset(tokenAfterOperator, operator, 0);
+         },
 
-                let firstBodyToken = sourceCode.getFirstToken(node);
-                let lastBodyToken = sourceCode.getLastToken(node);
+         'BlockStatement, ClassBody'(node) {
 
-                while (
-                    astUtils.isOpeningParenToken(sourceCode.getTokenBefore(firstBodyToken)) &&
-                    astUtils.isClosingParenToken(sourceCode.getTokenAfter(lastBodyToken))
-                ) {
-                    firstBodyToken = sourceCode.getTokenBefore(firstBodyToken);
-                    lastBodyToken = sourceCode.getTokenAfter(lastBodyToken);
-                }
+            let blockIndentLevel;
 
-                offsets.setDesiredOffsets([firstBodyToken.range[0], lastBodyToken.range[1]], lastParentToken, 1);
-
-                /*
-                 * For blockless nodes with semicolon-first style, don't indent the semicolon.
-                 * e.g.
-                 * if (foo) bar()
-                 * ; [1, 2, 3].map(foo)
-                 */
-                const lastToken = sourceCode.getLastToken(node);
-
-                if (node.type !== "EmptyStatement" && astUtils.isSemicolonToken(lastToken)) {
-                    offsets.setDesiredOffset(lastToken, lastParentToken, 0);
-                }
-            }
-        }
-
-        /**
-         * Checks the indentation for nodes that are like function calls (`CallExpression` and `NewExpression`)
-         * @param {ASTNode} node A CallExpression or NewExpression node
-         * @returns {void}
-         */
-        function addFunctionCallIndent(node) {
-            let openingParen;
-
-            if (node.arguments.length) {
-                openingParen = sourceCode.getFirstTokenBetween(node.callee, node.arguments[0], astUtils.isOpeningParenToken);
+            if (node.parent && isOuterIIFE(node.parent)) {
+               blockIndentLevel = options.outerIIFEBody;
+            } else if (node.parent && (node.parent.type === 'FunctionExpression' || node.parent.type === 'ArrowFunctionExpression')) {
+               blockIndentLevel = options.FunctionExpression.body;
+            } else if (node.parent && node.parent.type === 'FunctionDeclaration') {
+               blockIndentLevel = options.FunctionDeclaration.body;
             } else {
-                openingParen = sourceCode.getLastToken(node, 1);
+               blockIndentLevel = 1;
             }
-            const closingParen = sourceCode.getLastToken(node);
+
+            /*
+             * For blocks that aren't lone statements, ensure that the opening curly brace
+             * is aligned with the parent.
+             */
+            if (!astUtils.STATEMENT_LIST_PARENTS.has(node.parent.type)) {
+               offsets.setDesiredOffset(sourceCode.getFirstToken(node), sourceCode.getFirstToken(node.parent), 0);
+            }
+            addElementListIndent(node.body, sourceCode.getFirstToken(node), sourceCode.getLastToken(node), blockIndentLevel);
+         },
+
+         CallExpression: addFunctionCallIndent,
+
+
+         'ClassDeclaration[superClass], ClassExpression[superClass]'(node) {
+            const classToken = sourceCode.getFirstToken(node);
+
+            const extendsToken = sourceCode.getTokenBefore(node.superClass, astUtils.isNotOpeningParenToken);
+
+            offsets.setDesiredOffsets([ extendsToken.range[0], node.body.range[0] ], classToken, 1);
+         },
+
+         ConditionalExpression(node) {
+            const firstToken = sourceCode.getFirstToken(node),
+                  isOnSameLine = !astUtils.isTokenOnSameLine(node.test, node.consequent),
+                  isOnFirstLine = isOnFirstLineOfStatement(firstToken, node);
+
+            // `flatTernaryExpressions` option is for the following style:
+            // var a =
+            //     foo > 0 ? bar :
+            //     foo < 0 ? baz :
+            //     /*else*/ qiz ;
+            if (!options.flatTernaryExpressions || isOnSameLine || isOnFirstLine) {
+               const questionMarkToken = sourceCode.getFirstTokenBetween(
+                  node.test,
+                  node.consequent,
+                  (token) => token.type === 'Punctuator' && token.value === '?'
+               );
+
+               const colonToken = sourceCode.getFirstTokenBetween(
+                  node.consequent,
+                  node.alternate,
+                  (token) => token.type === 'Punctuator' && token.value === ':'
+               );
+
+               const firstConsequentToken = sourceCode.getTokenAfter(questionMarkToken);
+
+               const lastConsequentToken = sourceCode.getTokenBefore(colonToken);
+
+               const firstAlternateToken = sourceCode.getTokenAfter(colonToken);
+
+               offsets.setDesiredOffset(questionMarkToken, firstToken, 1);
+               offsets.setDesiredOffset(colonToken, firstToken, 1);
+
+               offsets.setDesiredOffset(firstConsequentToken, firstToken, 1);
+
+               /*
+                * The alternate and the consequent should usually have the same
+                * indentation.
+                * If they share part of a line, align the alternate against the first
+                * token of the consequent.
+                * This allows the alternate to be indented correctly in cases like this:
+                * foo ? (
+                *   bar
+                * ) : ( // this '(' is aligned with the '(' above, so it's considered to
+                *       // be aligned with `foo`
+                *   baz // as a result, `baz` is offset by 1 rather than 2
+                * )
+                */
+               if (lastConsequentToken.loc.end.line === firstAlternateToken.loc.start.line) {
+                  offsets.setDesiredOffset(firstAlternateToken, firstConsequentToken, 0);
+               } else {
+
+                  /**
+                   * If the alternate and consequent do not share part of a line, offset
+                   * the alternate from the first token of the conditional expression.
+                   * For example:
+                   * foo ? bar
+                   *   : baz
+                   *
+                   * If `baz` were aligned with `bar` rather than being offset by 1 from
+                   * `foo`, `baz` would end up having no expected indentation.
+                   */
+                  offsets.setDesiredOffset(firstAlternateToken, firstToken, 1);
+               }
+            }
+         },
+
+         'DoWhileStatement, WhileStatement, ForInStatement, ForOfStatement': (node) => addBlocklessNodeIndent(node.body),
+
+         ExportNamedDeclaration(node) {
+            if (node.declaration === null) {
+               const closingCurly = sourceCode.getLastToken(node, astUtils.isClosingBraceToken);
+
+               // Indent the specifiers in `export {foo, bar, baz}`
+               addElementListIndent(node.specifiers, sourceCode.getFirstToken(node, { skip: 1 }), closingCurly, 1);
+
+               if (node.source) {
+
+                  // Indent everything after and including the `from` token in `export
+                  // {foo, bar, baz} from 'qux'`
+                  offsets.setDesiredOffsets([ closingCurly.range[1], node.range[1] ], sourceCode.getFirstToken(node), 1);
+               }
+            }
+         },
+
+         ForStatement(node) {
+            const forOpeningParen = sourceCode.getFirstToken(node, 1);
+
+            if (node.init) {
+               offsets.setDesiredOffsets(node.init.range, forOpeningParen, 1);
+            }
+            if (node.test) {
+               offsets.setDesiredOffsets(node.test.range, forOpeningParen, 1);
+            }
+            if (node.update) {
+               offsets.setDesiredOffsets(node.update.range, forOpeningParen, 1);
+            }
+            addBlocklessNodeIndent(node.body);
+         },
+
+         'FunctionDeclaration, FunctionExpression'(node) {
+            const closingParen = sourceCode.getTokenBefore(node.body);
+
+            const openingParen = sourceCode.getTokenBefore(node.params.length ? node.params[0] : closingParen);
 
             parameterParens.add(openingParen);
             parameterParens.add(closingParen);
-            offsets.setDesiredOffset(openingParen, sourceCode.getTokenBefore(openingParen), 0);
+            addElementListIndent(node.params, openingParen, closingParen, options[node.type].parameters);
+         },
 
-            addElementListIndent(node.arguments, openingParen, closingParen, options.CallExpression.arguments);
-        }
-
-        /**
-         * Checks the indentation of parenthesized values, given a list of tokens in a program
-         * @param {Token[]} tokens A list of tokens
-         * @returns {void}
-         */
-        function addParensIndent(tokens) {
-            const parenStack = [];
-            const parenPairs = [];
-
-            tokens.forEach(nextToken => {
-
-                // Accumulate a list of parenthesis pairs
-                if (astUtils.isOpeningParenToken(nextToken)) {
-                    parenStack.push(nextToken);
-                } else if (astUtils.isClosingParenToken(nextToken)) {
-                    parenPairs.unshift({ left: parenStack.pop(), right: nextToken });
-                }
-            });
-
-            parenPairs.forEach(pair => {
-                const leftParen = pair.left;
-                const rightParen = pair.right;
-
-                // We only want to handle parens around expressions, so exclude parentheses that are in function parameters and function call arguments.
-                if (!parameterParens.has(leftParen) && !parameterParens.has(rightParen)) {
-                    const parenthesizedTokens = new Set(sourceCode.getTokensBetween(leftParen, rightParen));
-
-                    parenthesizedTokens.forEach(token => {
-                        if (!parenthesizedTokens.has(offsets.getFirstDependency(token))) {
-                            offsets.setDesiredOffset(token, leftParen, 1);
-                        }
-                    });
-                }
-
-                offsets.setDesiredOffset(rightParen, leftParen, 0);
-            });
-        }
-
-        /**
-         * Ignore all tokens within an unknown node whose offset do not depend
-         * on another token's offset within the unknown node
-         * @param {ASTNode} node Unknown Node
-         * @returns {void}
-         */
-        function ignoreNode(node) {
-            const unknownNodeTokens = new Set(sourceCode.getTokens(node, { includeComments: true }));
-
-            unknownNodeTokens.forEach(token => {
-                if (!unknownNodeTokens.has(offsets.getFirstDependency(token))) {
-                    const firstTokenOfLine = tokenInfo.getFirstTokenOfLine(token);
-
-                    if (token === firstTokenOfLine) {
-                        offsets.ignoreToken(token);
-                    } else {
-                        offsets.setDesiredOffset(token, firstTokenOfLine, 0);
-                    }
-                }
-            });
-        }
-
-        /**
-         * Check whether the given token is on the first line of a statement.
-         * @param {Token} token The token to check.
-         * @param {ASTNode} leafNode The expression node that the token belongs directly.
-         * @returns {boolean} `true` if the token is on the first line of a statement.
-         */
-        function isOnFirstLineOfStatement(token, leafNode) {
-            let node = leafNode;
-
-            while (node.parent && !node.parent.type.endsWith("Statement") && !node.parent.type.endsWith("Declaration")) {
-                node = node.parent;
+         IfStatement(node) {
+            addBlocklessNodeIndent(node.consequent);
+            if (node.alternate && node.alternate.type !== 'IfStatement') {
+               addBlocklessNodeIndent(node.alternate);
             }
-            node = node.parent;
+         },
 
-            return !node || node.loc.start.line === token.loc.start.line;
-        }
+         ImportDeclaration(node) {
+            if (node.specifiers.some((specifier) => specifier.type === 'ImportSpecifier')) {
+               const openingCurly = sourceCode.getFirstToken(node, astUtils.isOpeningBraceToken),
+                     closingCurly = sourceCode.getLastToken(node, astUtils.isClosingBraceToken),
+                     nodeSpecifierFilter = (specifier) => specifier.type === 'ImportSpecifier';
 
-        /**
-         * Check whether there are any blank (whitespace-only) lines between
-         * two tokens on separate lines.
-         * @param {Token} firstToken The first token.
-         * @param {Token} secondToken The second token.
-         * @returns {boolean} `true` if the tokens are on separate lines and
-         *   there exists a blank line between them, `false` otherwise.
-         */
-        function hasBlankLinesBetween(firstToken, secondToken) {
-            const firstTokenLine = firstToken.loc.end.line;
-            const secondTokenLine = secondToken.loc.start.line;
-
-            if (firstTokenLine === secondTokenLine || firstTokenLine === secondTokenLine - 1) {
-                return false;
+               addElementListIndent(node.specifiers.filter(nodeSpecifierFilter), openingCurly, closingCurly, options.ImportDeclaration);
             }
 
-            for (let line = firstTokenLine + 1; line < secondTokenLine; ++line) {
-                if (!tokenInfo.firstTokensByLineNumber.has(line)) {
-                    return true;
-                }
+            const fromToken = sourceCode.getLastToken(node, (token) => token.type === 'Identifier' && token.value === 'from');
+
+            const sourceToken = sourceCode.getLastToken(node, (token) => token.type === 'String');
+
+            const semiToken = sourceCode.getLastToken(node, (token) => token.type === 'Punctuator' && token.value === ';');
+
+            if (fromToken) {
+               const end = semiToken && semiToken.range[1] === sourceToken.range[1] ? node.range[1] : sourceToken.range[1];
+
+               offsets.setDesiredOffsets([ fromToken.range[0], end ], sourceCode.getFirstToken(node), 1);
             }
+         },
 
-            return false;
-        }
+         'MemberExpression, JSXMemberExpression, MetaProperty'(node) {
+            const object = node.type === 'MetaProperty' ? node.meta : node.object;
 
-        const ignoredNodeFirstTokens = new Set();
+            const firstNonObjectToken = sourceCode.getFirstTokenBetween(object, node.property, astUtils.isNotClosingParenToken);
 
-        const baseOffsetListeners = {
-            "ArrayExpression, ArrayPattern"(node) {
-                const openingBracket = sourceCode.getFirstToken(node);
-                const closingBracket = sourceCode.getTokenAfter(lodash.findLast(node.elements) || openingBracket, astUtils.isClosingBracketToken);
+            const secondNonObjectToken = sourceCode.getTokenAfter(firstNonObjectToken);
 
-                addElementListIndent(node.elements, openingBracket, closingBracket, options.ArrayExpression);
-            },
+            const objectParenCount = sourceCode.getTokensBetween(object, node.property, { filter: astUtils.isClosingParenToken }).length;
 
-            "ObjectExpression, ObjectPattern"(node) {
-                const openingCurly = sourceCode.getFirstToken(node);
-                const closingCurly = sourceCode.getTokenAfter(
-                    node.properties.length ? node.properties[node.properties.length - 1] : openingCurly,
-                    astUtils.isClosingBraceToken
-                );
-
-                addElementListIndent(node.properties, openingCurly, closingCurly, options.ObjectExpression);
-            },
-
-            ArrowFunctionExpression(node) {
-                const firstToken = sourceCode.getFirstToken(node);
-
-                if (astUtils.isOpeningParenToken(firstToken)) {
-                    const openingParen = firstToken;
-                    const closingParen = sourceCode.getTokenBefore(node.body, astUtils.isClosingParenToken);
-
-                    parameterParens.add(openingParen);
-                    parameterParens.add(closingParen);
-                    addElementListIndent(node.params, openingParen, closingParen, options.FunctionExpression.parameters);
-                }
-                addBlocklessNodeIndent(node.body);
-            },
-
-            AssignmentExpression(node) {
-                const operator = sourceCode.getFirstTokenBetween(node.left, node.right, token => token.value === node.operator);
-
-                offsets.setDesiredOffsets([operator.range[0], node.range[1]], sourceCode.getLastToken(node.left), 1);
-                offsets.ignoreToken(operator);
-                offsets.ignoreToken(sourceCode.getTokenAfter(operator));
-            },
-
-            "BinaryExpression, LogicalExpression"(node) {
-                const operator = sourceCode.getFirstTokenBetween(node.left, node.right, token => token.value === node.operator);
-
-                /*
-                 * For backwards compatibility, don't check BinaryExpression indents, e.g.
-                 * var foo = bar &&
-                 *                   baz;
-                 */
-
-                const tokenAfterOperator = sourceCode.getTokenAfter(operator);
-
-                offsets.ignoreToken(operator);
-                offsets.ignoreToken(tokenAfterOperator);
-                offsets.setDesiredOffset(tokenAfterOperator, operator, 0);
-            },
-
-            "BlockStatement, ClassBody"(node) {
-
-                let blockIndentLevel;
-
-                if (node.parent && isOuterIIFE(node.parent)) {
-                    blockIndentLevel = options.outerIIFEBody;
-                } else if (node.parent && (node.parent.type === "FunctionExpression" || node.parent.type === "ArrowFunctionExpression")) {
-                    blockIndentLevel = options.FunctionExpression.body;
-                } else if (node.parent && node.parent.type === "FunctionDeclaration") {
-                    blockIndentLevel = options.FunctionDeclaration.body;
-                } else {
-                    blockIndentLevel = 1;
-                }
-
-                /*
-                 * For blocks that aren't lone statements, ensure that the opening curly brace
-                 * is aligned with the parent.
-                 */
-                if (!astUtils.STATEMENT_LIST_PARENTS.has(node.parent.type)) {
-                    offsets.setDesiredOffset(sourceCode.getFirstToken(node), sourceCode.getFirstToken(node.parent), 0);
-                }
-                addElementListIndent(node.body, sourceCode.getFirstToken(node), sourceCode.getLastToken(node), blockIndentLevel);
-            },
-
-            CallExpression: addFunctionCallIndent,
-
-
-            "ClassDeclaration[superClass], ClassExpression[superClass]"(node) {
-                const classToken = sourceCode.getFirstToken(node);
-                const extendsToken = sourceCode.getTokenBefore(node.superClass, astUtils.isNotOpeningParenToken);
-
-                offsets.setDesiredOffsets([extendsToken.range[0], node.body.range[0]], classToken, 1);
-            },
-
-            ConditionalExpression(node) {
-                const firstToken = sourceCode.getFirstToken(node);
-
-                // `flatTernaryExpressions` option is for the following style:
-                // var a =
-                //     foo > 0 ? bar :
-                //     foo < 0 ? baz :
-                //     /*else*/ qiz ;
-                if (!options.flatTernaryExpressions ||
-                    !astUtils.isTokenOnSameLine(node.test, node.consequent) ||
-                    isOnFirstLineOfStatement(firstToken, node)
-                ) {
-                    const questionMarkToken = sourceCode.getFirstTokenBetween(node.test, node.consequent, token => token.type === "Punctuator" && token.value === "?");
-                    const colonToken = sourceCode.getFirstTokenBetween(node.consequent, node.alternate, token => token.type === "Punctuator" && token.value === ":");
-
-                    const firstConsequentToken = sourceCode.getTokenAfter(questionMarkToken);
-                    const lastConsequentToken = sourceCode.getTokenBefore(colonToken);
-                    const firstAlternateToken = sourceCode.getTokenAfter(colonToken);
-
-                    offsets.setDesiredOffset(questionMarkToken, firstToken, 1);
-                    offsets.setDesiredOffset(colonToken, firstToken, 1);
-
-                    offsets.setDesiredOffset(firstConsequentToken, firstToken, 1);
-
-                    /*
-                     * The alternate and the consequent should usually have the same indentation.
-                     * If they share part of a line, align the alternate against the first token of the consequent.
-                     * This allows the alternate to be indented correctly in cases like this:
-                     * foo ? (
-                     *   bar
-                     * ) : ( // this '(' is aligned with the '(' above, so it's considered to be aligned with `foo`
-                     *   baz // as a result, `baz` is offset by 1 rather than 2
-                     * )
-                     */
-                    if (lastConsequentToken.loc.end.line === firstAlternateToken.loc.start.line) {
-                        offsets.setDesiredOffset(firstAlternateToken, firstConsequentToken, 0);
-                    } else {
-
-                        /**
-                         * If the alternate and consequent do not share part of a line, offset the alternate from the first
-                         * token of the conditional expression. For example:
-                         * foo ? bar
-                         *   : baz
-                         *
-                         * If `baz` were aligned with `bar` rather than being offset by 1 from `foo`, `baz` would end up
-                         * having no expected indentation.
-                         */
-                        offsets.setDesiredOffset(firstAlternateToken, firstToken, 1);
-                    }
-                }
-            },
-
-            "DoWhileStatement, WhileStatement, ForInStatement, ForOfStatement": node => addBlocklessNodeIndent(node.body),
-
-            ExportNamedDeclaration(node) {
-                if (node.declaration === null) {
-                    const closingCurly = sourceCode.getLastToken(node, astUtils.isClosingBraceToken);
-
-                    // Indent the specifiers in `export {foo, bar, baz}`
-                    addElementListIndent(node.specifiers, sourceCode.getFirstToken(node, { skip: 1 }), closingCurly, 1);
-
-                    if (node.source) {
-
-                        // Indent everything after and including the `from` token in `export {foo, bar, baz} from 'qux'`
-                        offsets.setDesiredOffsets([closingCurly.range[1], node.range[1]], sourceCode.getFirstToken(node), 1);
-                    }
-                }
-            },
-
-            ForStatement(node) {
-                const forOpeningParen = sourceCode.getFirstToken(node, 1);
-
-                if (node.init) {
-                    offsets.setDesiredOffsets(node.init.range, forOpeningParen, 1);
-                }
-                if (node.test) {
-                    offsets.setDesiredOffsets(node.test.range, forOpeningParen, 1);
-                }
-                if (node.update) {
-                    offsets.setDesiredOffsets(node.update.range, forOpeningParen, 1);
-                }
-                addBlocklessNodeIndent(node.body);
-            },
-
-            "FunctionDeclaration, FunctionExpression"(node) {
-                const closingParen = sourceCode.getTokenBefore(node.body);
-                const openingParen = sourceCode.getTokenBefore(node.params.length ? node.params[0] : closingParen);
-
-                parameterParens.add(openingParen);
-                parameterParens.add(closingParen);
-                addElementListIndent(node.params, openingParen, closingParen, options[node.type].parameters);
-            },
-
-            IfStatement(node) {
-                addBlocklessNodeIndent(node.consequent);
-                if (node.alternate && node.alternate.type !== "IfStatement") {
-                    addBlocklessNodeIndent(node.alternate);
-                }
-            },
-
-            ImportDeclaration(node) {
-                if (node.specifiers.some(specifier => specifier.type === "ImportSpecifier")) {
-                    const openingCurly = sourceCode.getFirstToken(node, astUtils.isOpeningBraceToken);
-                    const closingCurly = sourceCode.getLastToken(node, astUtils.isClosingBraceToken);
-
-                    addElementListIndent(node.specifiers.filter(specifier => specifier.type === "ImportSpecifier"), openingCurly, closingCurly, options.ImportDeclaration);
-                }
-
-                const fromToken = sourceCode.getLastToken(node, token => token.type === "Identifier" && token.value === "from");
-                const sourceToken = sourceCode.getLastToken(node, token => token.type === "String");
-                const semiToken = sourceCode.getLastToken(node, token => token.type === "Punctuator" && token.value === ";");
-
-                if (fromToken) {
-                    const end = semiToken && semiToken.range[1] === sourceToken.range[1] ? node.range[1] : sourceToken.range[1];
-
-                    offsets.setDesiredOffsets([fromToken.range[0], end], sourceCode.getFirstToken(node), 1);
-                }
-            },
-
-            "MemberExpression, JSXMemberExpression, MetaProperty"(node) {
-                const object = node.type === "MetaProperty" ? node.meta : node.object;
-                const firstNonObjectToken = sourceCode.getFirstTokenBetween(object, node.property, astUtils.isNotClosingParenToken);
-                const secondNonObjectToken = sourceCode.getTokenAfter(firstNonObjectToken);
-
-                const objectParenCount = sourceCode.getTokensBetween(object, node.property, { filter: astUtils.isClosingParenToken }).length;
-                const firstObjectToken = objectParenCount
+            const firstObjectToken = objectParenCount
                     ? sourceCode.getTokenBefore(object, { skip: objectParenCount - 1 })
                     : sourceCode.getFirstToken(object);
-                const lastObjectToken = sourceCode.getTokenBefore(firstNonObjectToken);
-                const firstPropertyToken = node.computed ? firstNonObjectToken : secondNonObjectToken;
 
-                if (node.computed) {
+            const lastObjectToken = sourceCode.getTokenBefore(firstNonObjectToken);
 
-                    // For computed MemberExpressions, match the closing bracket with the opening bracket.
-                    offsets.setDesiredOffset(sourceCode.getLastToken(node), firstNonObjectToken, 0);
-                    offsets.setDesiredOffsets(node.property.range, firstNonObjectToken, 1);
-                }
+            const firstPropertyToken = node.computed ? firstNonObjectToken : secondNonObjectToken;
 
-                /*
-                 * If the object ends on the same line that the property starts, match against the last token
-                 * of the object, to ensure that the MemberExpression is not indented.
-                 *
-                 * Otherwise, match against the first token of the object, e.g.
-                 * foo
-                 *   .bar
-                 *   .baz // <-- offset by 1 from `foo`
-                 */
-                const offsetBase = lastObjectToken.loc.end.line === firstPropertyToken.loc.start.line
+            if (node.computed) {
+               // For computed MemberExpressions, match the closing bracket with the
+               // opening bracket.
+               offsets.setDesiredOffset(sourceCode.getLastToken(node), firstNonObjectToken, 0);
+               offsets.setDesiredOffsets(node.property.range, firstNonObjectToken, 1);
+            }
+
+            /*
+             * If the object ends on the same line that the property starts, match against
+             * the last token of the object, to ensure that the MemberExpression is not
+             * indented.
+             *
+             * Otherwise, match against the first token of the object, e.g.
+             * foo
+             *   .bar
+             *   .baz // <-- offset by 1 from `foo`
+             */
+            const offsetBase = lastObjectToken.loc.end.line === firstPropertyToken.loc.start.line
                     ? lastObjectToken
                     : firstObjectToken;
 
-                if (typeof options.MemberExpression === "number") {
+            if (typeof options.MemberExpression === 'number') {
 
-                    // Match the dot (for non-computed properties) or the opening bracket (for computed properties) against the object.
-                    offsets.setDesiredOffset(firstNonObjectToken, offsetBase, options.MemberExpression);
+               // Match the dot (for non-computed properties) or the opening bracket (for
+               // computed properties) against the object.
+               offsets.setDesiredOffset(firstNonObjectToken, offsetBase, options.MemberExpression);
 
-                    /*
-                     * For computed MemberExpressions, match the first token of the property against the opening bracket.
-                     * Otherwise, match the first token of the property against the object.
-                     */
-                    offsets.setDesiredOffset(secondNonObjectToken, node.computed ? firstNonObjectToken : offsetBase, options.MemberExpression);
-                } else {
+               /*
+                * For computed MemberExpressions, match the first token of the property
+                * against the opening bracket. Otherwise, match the first token of the
+                * property against the object.
+                */
+               offsets.setDesiredOffset(secondNonObjectToken, node.computed ? firstNonObjectToken : offsetBase, options.MemberExpression);
+            } else {
 
-                    // If the MemberExpression option is off, ignore the dot and the first token of the property.
-                    offsets.ignoreToken(firstNonObjectToken);
-                    offsets.ignoreToken(secondNonObjectToken);
+               // If the MemberExpression option is off, ignore the dot and the first
+               // token of the property.
+               offsets.ignoreToken(firstNonObjectToken);
+               offsets.ignoreToken(secondNonObjectToken);
 
-                    // To ignore the property indentation, ensure that the property tokens depend on the ignored tokens.
-                    offsets.setDesiredOffset(firstNonObjectToken, offsetBase, 0);
-                    offsets.setDesiredOffset(secondNonObjectToken, firstNonObjectToken, 0);
-                }
-            },
+               // To ignore the property indentation, ensure that the property tokens
+               // depend on the ignored tokens.
+               offsets.setDesiredOffset(firstNonObjectToken, offsetBase, 0);
+               offsets.setDesiredOffset(secondNonObjectToken, firstNonObjectToken, 0);
+            }
+         },
 
-            NewExpression(node) {
+         NewExpression(node) {
+            const isClosingParen = astUtils.isClosingParenToken(sourceCode.getLastToken(node)),
+                  isOpeningParen = astUtils.isOpeningParenToken(sourceCode.getLastToken(node, 1));
 
-                // Only indent the arguments if the NewExpression has parens (e.g. `new Foo(bar)` or `new Foo()`, but not `new Foo`
-                if (node.arguments.length > 0 ||
-                        astUtils.isClosingParenToken(sourceCode.getLastToken(node)) &&
-                        astUtils.isOpeningParenToken(sourceCode.getLastToken(node, 1))) {
-                    addFunctionCallIndent(node);
-                }
-            },
+            // Only indent the arguments if the NewExpression has parens (e.g. `new
+            // Foo(bar)` or `new Foo()`, but not `new Foo`
+            if (node.arguments.length > 0 || isClosingParen && isOpeningParen) {
+               addFunctionCallIndent(node);
+            }
+         },
 
-            Property(node) {
-                if (!node.shorthand && !node.method && node.kind === "init") {
-                    const colon = sourceCode.getFirstTokenBetween(node.key, node.value, astUtils.isColonToken);
+         Property(node) {
+            if (!node.shorthand && !node.method && node.kind === 'init') {
+               const colon = sourceCode.getFirstTokenBetween(node.key, node.value, astUtils.isColonToken);
 
-                    offsets.ignoreToken(sourceCode.getTokenAfter(colon));
-                }
-            },
+               offsets.ignoreToken(sourceCode.getTokenAfter(colon));
+            }
+         },
 
-            SwitchStatement(node) {
-                const openingCurly = sourceCode.getTokenAfter(node.discriminant, astUtils.isOpeningBraceToken);
-                const closingCurly = sourceCode.getLastToken(node);
+         SwitchStatement(node) {
+            const openingCurly = sourceCode.getTokenAfter(node.discriminant, astUtils.isOpeningBraceToken);
 
-                offsets.setDesiredOffsets([openingCurly.range[1], closingCurly.range[0]], openingCurly, options.SwitchCase);
+            const closingCurly = sourceCode.getLastToken(node);
 
-                if (node.cases.length) {
-                    sourceCode.getTokensBetween(
-                        node.cases[node.cases.length - 1],
-                        closingCurly,
-                        { includeComments: true, filter: astUtils.isCommentToken }
-                    ).forEach(token => offsets.ignoreToken(token));
-                }
-            },
+            offsets.setDesiredOffsets([ openingCurly.range[1], closingCurly.range[0] ], openingCurly, options.SwitchCase);
 
-            SwitchCase(node) {
-                if (!(node.consequent.length === 1 && node.consequent[0].type === "BlockStatement")) {
-                    const caseKeyword = sourceCode.getFirstToken(node);
-                    const tokenAfterCurrentCase = sourceCode.getTokenAfter(node);
+            if (node.cases.length) {
+               const tokensBetween = sourceCode.getTokensBetween(
+                  node.cases[node.cases.length - 1],
+                  closingCurly,
+                  { includeComments: true, filter: astUtils.isCommentToken }
+               );
 
-                    offsets.setDesiredOffsets([caseKeyword.range[1], tokenAfterCurrentCase.range[0]], caseKeyword, 1);
-                }
-            },
+               tokensBetween.forEach((token) => offsets.ignoreToken(token));
+            }
+         },
 
-            TemplateLiteral(node) {
-                node.expressions.forEach((expression, index) => {
-                    const previousQuasi = node.quasis[index];
-                    const nextQuasi = node.quasis[index + 1];
-                    const tokenToAlignFrom = previousQuasi.loc.start.line === previousQuasi.loc.end.line
+         SwitchCase(node) {
+            if (!(node.consequent.length === 1 && node.consequent[0].type === 'BlockStatement')) {
+               const caseKeyword = sourceCode.getFirstToken(node);
+
+               const tokenAfterCurrentCase = sourceCode.getTokenAfter(node);
+
+               offsets.setDesiredOffsets([ caseKeyword.range[1], tokenAfterCurrentCase.range[0] ], caseKeyword, 1);
+            }
+         },
+
+         TemplateLiteral(node) {
+            node.expressions.forEach((expression, index) => {
+               const previousQuasi = node.quasis[index];
+
+               const nextQuasi = node.quasis[index + 1];
+
+               const tokenToAlignFrom = previousQuasi.loc.start.line === previousQuasi.loc.end.line
                         ? sourceCode.getFirstToken(previousQuasi)
                         : null;
 
-                    offsets.setDesiredOffsets([previousQuasi.range[1], nextQuasi.range[0]], tokenToAlignFrom, 1);
-                    offsets.setDesiredOffset(sourceCode.getFirstToken(nextQuasi), tokenToAlignFrom, 0);
-                });
-            },
+               offsets.setDesiredOffsets([ previousQuasi.range[1], nextQuasi.range[0] ], tokenToAlignFrom, 1);
+               offsets.setDesiredOffset(sourceCode.getFirstToken(nextQuasi), tokenToAlignFrom, 0);
+            });
+         },
 
-            VariableDeclaration(node) {
-                const variableIndent = Object.prototype.hasOwnProperty.call(options.VariableDeclarator, node.kind)
+         VariableDeclaration(node) {
+            const variableIndent = Object.prototype.hasOwnProperty.call(options.VariableDeclarator, node.kind)
                     ? options.VariableDeclarator[node.kind]
                     : DEFAULT_VARIABLE_INDENT;
 
-                if (node.declarations[node.declarations.length - 1].loc.start.line > node.loc.start.line) {
+            if (node.declarations[node.declarations.length - 1].loc.start.line > node.loc.start.line) {
 
-                    /*
-                     * VariableDeclarator indentation is a bit different from other forms of indentation, in that the
-                     * indentation of an opening bracket sometimes won't match that of a closing bracket. For example,
-                     * the following indentations are correct:
-                     *
-                     * var foo = {
-                     *   ok: true
-                     * };
-                     *
-                     * var foo = {
-                     *     ok: true,
-                     *   },
-                     *   bar = 1;
-                     *
-                     * Account for when exiting the AST (after indentations have already been set for the nodes in
-                     * the declaration) by manually increasing the indentation level of the tokens in this declarator
-                     * on the same line as the start of the declaration, provided that there are declarators that
-                     * follow this one.
-                     */
-                    const firstToken = sourceCode.getFirstToken(node);
+               /*
+                * VariableDeclarator indentation is a bit different from other forms of
+                * indentation, in that the indentation of an opening bracket sometimes
+                * won't match that of a closing bracket. For example, the following
+                * indentations are correct:
+                *
+                * var foo = {
+                *   ok: true
+                * };
+                *
+                * var foo = {
+                *     ok: true,
+                *   },
+                *   bar = 1;
+                *
+                * Account for when exiting the AST (after indentations have already been
+                * set for the nodes in the declaration) by manually increasing the
+                * indentation level of the tokens in this declarator on the same line as
+                * the start of the declaration, provided that there are declarators that
+                * follow this one.
+                */
+               const firstToken = sourceCode.getFirstToken(node);
 
-                    offsets.setDesiredOffsets(node.range, firstToken, variableIndent, true);
-                } else {
-                    offsets.setDesiredOffsets(node.range, sourceCode.getFirstToken(node), variableIndent);
-                }
-                const lastToken = sourceCode.getLastToken(node);
-
-                if (astUtils.isSemicolonToken(lastToken)) {
-                    offsets.ignoreToken(lastToken);
-                }
-            },
-
-            VariableDeclarator(node) {
-                if (node.init) {
-                    const equalOperator = sourceCode.getTokenBefore(node.init, astUtils.isNotOpeningParenToken);
-                    const tokenAfterOperator = sourceCode.getTokenAfter(equalOperator);
-
-                    offsets.ignoreToken(equalOperator);
-                    offsets.ignoreToken(tokenAfterOperator);
-                    offsets.setDesiredOffsets([tokenAfterOperator.range[0], node.range[1]], equalOperator, 1);
-                    offsets.setDesiredOffset(equalOperator, sourceCode.getLastToken(node.id), 0);
-                }
-            },
-
-            "JSXAttribute[value]"(node) {
-                const equalsToken = sourceCode.getFirstTokenBetween(node.name, node.value, token => token.type === "Punctuator" && token.value === "=");
-
-                offsets.setDesiredOffsets([equalsToken.range[0], node.value.range[1]], sourceCode.getFirstToken(node.name), 1);
-            },
-
-            JSXElement(node) {
-                if (node.closingElement) {
-                    addElementListIndent(node.children, sourceCode.getFirstToken(node.openingElement), sourceCode.getFirstToken(node.closingElement), 1);
-                }
-            },
-
-            JSXOpeningElement(node) {
-                const firstToken = sourceCode.getFirstToken(node);
-                let closingToken;
-
-                if (node.selfClosing) {
-                    closingToken = sourceCode.getLastToken(node, { skip: 1 });
-                    offsets.setDesiredOffset(sourceCode.getLastToken(node), closingToken, 0);
-                } else {
-                    closingToken = sourceCode.getLastToken(node);
-                }
-                offsets.setDesiredOffsets(node.name.range, sourceCode.getFirstToken(node));
-                addElementListIndent(node.attributes, firstToken, closingToken, 1);
-            },
-
-            JSXClosingElement(node) {
-                const firstToken = sourceCode.getFirstToken(node);
-
-                offsets.setDesiredOffsets(node.name.range, firstToken, 1);
-            },
-
-            JSXExpressionContainer(node) {
-                const openingCurly = sourceCode.getFirstToken(node);
-                const closingCurly = sourceCode.getLastToken(node);
-
-                offsets.setDesiredOffsets(
-                    [openingCurly.range[1], closingCurly.range[0]],
-                    openingCurly,
-                    1
-                );
-            },
-
-            "*"(node) {
-                const firstToken = sourceCode.getFirstToken(node);
-
-                // Ensure that the children of every node are indented at least as much as the first token.
-                if (firstToken && !ignoredNodeFirstTokens.has(firstToken)) {
-                    offsets.setDesiredOffsets(node.range, firstToken, 0);
-                }
+               offsets.setDesiredOffsets(node.range, firstToken, variableIndent, true);
+            } else {
+               offsets.setDesiredOffsets(node.range, sourceCode.getFirstToken(node), variableIndent);
             }
-        };
+            const lastToken = sourceCode.getLastToken(node);
 
-        const listenerCallQueue = [];
-
-        /*
-         * To ignore the indentation of a node:
-         * 1. Don't call the node's listener when entering it (if it has a listener)
-         * 2. Don't set any offsets against the first token of the node.
-         * 3. Call `ignoreNode` on the node sometime after exiting it and before validating offsets.
-         */
-        const offsetListeners = lodash.mapValues(
-            baseOffsetListeners,
-
-            /*
-             * Offset listener calls are deferred until traversal is finished, and are called as
-             * part of the final `Program:exit` listener. This is necessary because a node might
-             * be matched by multiple selectors.
-             *
-             * Example: Suppose there is an offset listener for `Identifier`, and the user has
-             * specified in configuration that `MemberExpression > Identifier` should be ignored.
-             * Due to selector specificity rules, the `Identifier` listener will get called first. However,
-             * if a given Identifier node is supposed to be ignored, then the `Identifier` offset listener
-             * should not have been called at all. Without doing extra selector matching, we don't know
-             * whether the Identifier matches the `MemberExpression > Identifier` selector until the
-             * `MemberExpression > Identifier` listener is called.
-             *
-             * To avoid this, the `Identifier` listener isn't called until traversal finishes and all
-             * ignored nodes are known.
-             */
-            listener =>
-                node =>
-                    listenerCallQueue.push({ listener, node })
-        );
-
-        // For each ignored node selector, set up a listener to collect it into the `ignoredNodes` set.
-        const ignoredNodes = new Set();
-
-        /**
-         * Ignores a node
-         * @param {ASTNode} node The node to ignore
-         * @returns {void}
-         */
-        function addToIgnoredNodes(node) {
-            ignoredNodes.add(node);
-            ignoredNodeFirstTokens.add(sourceCode.getFirstToken(node));
-        }
-
-        const ignoredNodeListeners = options.ignoredNodes.reduce(
-            (listeners, ignoredSelector) => Object.assign(listeners, { [ignoredSelector]: addToIgnoredNodes }),
-            {}
-        );
-
-        /*
-         * Join the listeners, and add a listener to verify that all tokens actually have the correct indentation
-         * at the end.
-         *
-         * Using Object.assign will cause some offset listeners to be overwritten if the same selector also appears
-         * in `ignoredNodeListeners`. This isn't a problem because all of the matching nodes will be ignored,
-         * so those listeners wouldn't be called anyway.
-         */
-        return Object.assign(
-            offsetListeners,
-            ignoredNodeListeners,
-            {
-                "*:exit"(node) {
-
-                    // If a node's type is nonstandard, we can't tell how its children should be offset, so ignore it.
-                    if (!KNOWN_NODES.has(node.type)) {
-                        addToIgnoredNodes(node);
-                    }
-                },
-                "Program:exit"() {
-
-                    // If ignoreComments option is enabled, ignore all comment tokens.
-                    if (options.ignoreComments) {
-                        sourceCode.getAllComments()
-                            .forEach(comment => offsets.ignoreToken(comment));
-                    }
-
-                    // Invoke the queued offset listeners for the nodes that aren't ignored.
-                    listenerCallQueue
-                        .filter(nodeInfo => !ignoredNodes.has(nodeInfo.node))
-                        .forEach(nodeInfo => nodeInfo.listener(nodeInfo.node));
-
-                    // Update the offsets for ignored nodes to prevent their child tokens from being reported.
-                    ignoredNodes.forEach(ignoreNode);
-
-                    addParensIndent(sourceCode.ast.tokens);
-
-                    /*
-                     * Create a Map from (tokenOrComment) => (precedingToken).
-                     * This is necessary because sourceCode.getTokenBefore does not handle a comment as an argument correctly.
-                     */
-                    const precedingTokens = sourceCode.ast.comments.reduce((commentMap, comment) => {
-                        const tokenOrCommentBefore = sourceCode.getTokenBefore(comment, { includeComments: true });
-
-                        return commentMap.set(comment, commentMap.has(tokenOrCommentBefore) ? commentMap.get(tokenOrCommentBefore) : tokenOrCommentBefore);
-                    }, new WeakMap());
-
-                    sourceCode.lines.forEach((line, lineIndex) => {
-                        const lineNumber = lineIndex + 1;
-
-                        if (!tokenInfo.firstTokensByLineNumber.has(lineNumber)) {
-
-                            // Don't check indentation on blank lines
-                            return;
-                        }
-
-                        const firstTokenOfLine = tokenInfo.firstTokensByLineNumber.get(lineNumber);
-
-                        if (firstTokenOfLine.loc.start.line !== lineNumber) {
-
-                            // Don't check the indentation of multi-line tokens (e.g. template literals or block comments) twice.
-                            return;
-                        }
-
-                        // If the token matches the expected expected indentation, don't report it.
-                        if (validateTokenIndent(firstTokenOfLine, offsets.getDesiredIndent(firstTokenOfLine))) {
-                            return;
-                        }
-
-                        if (astUtils.isCommentToken(firstTokenOfLine)) {
-                            const tokenBefore = precedingTokens.get(firstTokenOfLine);
-                            const tokenAfter = tokenBefore ? sourceCode.getTokenAfter(tokenBefore) : sourceCode.ast.tokens[0];
-
-                            const mayAlignWithBefore = tokenBefore && !hasBlankLinesBetween(tokenBefore, firstTokenOfLine);
-                            const mayAlignWithAfter = tokenAfter && !hasBlankLinesBetween(firstTokenOfLine, tokenAfter);
-
-                            // If a comment matches the expected indentation of the token immediately before or after, don't report it.
-                            if (
-                                mayAlignWithBefore && validateTokenIndent(firstTokenOfLine, offsets.getDesiredIndent(tokenBefore)) ||
-                                mayAlignWithAfter && validateTokenIndent(firstTokenOfLine, offsets.getDesiredIndent(tokenAfter))
-                            ) {
-                                return;
-                            }
-                        }
-
-                        // Otherwise, report the token/comment.
-                        report(firstTokenOfLine, offsets.getDesiredIndent(firstTokenOfLine));
-                    });
-                }
+            if (astUtils.isSemicolonToken(lastToken)) {
+               offsets.ignoreToken(lastToken);
             }
-        );
-    }
+         },
+
+         VariableDeclarator(node) {
+            if (node.init) {
+               const equalOperator = sourceCode.getTokenBefore(node.init, astUtils.isNotOpeningParenToken);
+
+               const tokenAfterOperator = sourceCode.getTokenAfter(equalOperator);
+
+               offsets.ignoreToken(equalOperator);
+               offsets.ignoreToken(tokenAfterOperator);
+               offsets.setDesiredOffsets([ tokenAfterOperator.range[0], node.range[1] ], equalOperator, 1);
+               offsets.setDesiredOffset(equalOperator, sourceCode.getLastToken(node.id), 0);
+            }
+         },
+
+         'JSXAttribute[value]'(node) {
+            const equalsToken = sourceCode.getFirstTokenBetween(
+               node.name,
+               node.value,
+               (token) => token.type === 'Punctuator' && token.value === '='
+            );
+
+            offsets.setDesiredOffsets([ equalsToken.range[0], node.value.range[1] ], sourceCode.getFirstToken(node.name), 1);
+         },
+
+         JSXElement(node) {
+            if (node.closingElement) {
+               addElementListIndent(
+                  node.children,
+                  sourceCode.getFirstToken(node.openingElement),
+                  sourceCode.getFirstToken(node.closingElement),
+                  1
+               );
+            }
+         },
+
+         JSXOpeningElement(node) {
+            const firstToken = sourceCode.getFirstToken(node);
+
+            let closingToken;
+
+            if (node.selfClosing) {
+               closingToken = sourceCode.getLastToken(node, { skip: 1 });
+               offsets.setDesiredOffset(sourceCode.getLastToken(node), closingToken, 0);
+            } else {
+               closingToken = sourceCode.getLastToken(node);
+            }
+            offsets.setDesiredOffsets(node.name.range, sourceCode.getFirstToken(node));
+            addElementListIndent(node.attributes, firstToken, closingToken, 1);
+         },
+
+         JSXClosingElement(node) {
+            const firstToken = sourceCode.getFirstToken(node);
+
+            offsets.setDesiredOffsets(node.name.range, firstToken, 1);
+         },
+
+         JSXExpressionContainer(node) {
+            const openingCurly = sourceCode.getFirstToken(node);
+
+            const closingCurly = sourceCode.getLastToken(node);
+
+            offsets.setDesiredOffsets([ openingCurly.range[1], closingCurly.range[0] ], openingCurly, 1);
+         },
+
+         '*'(node) {
+            const firstToken = sourceCode.getFirstToken(node);
+
+            // Ensure that the children of every node are indented at least as much as the
+            // first token.
+            if (firstToken && !ignoredNodeFirstTokens.has(firstToken)) {
+               offsets.setDesiredOffsets(node.range, firstToken, 0);
+            }
+         },
+      };
+
+      const listenerCallQueue = [];
+
+      /*
+       * To ignore the indentation of a node:
+       * 1. Don't call the node's listener when entering it (if it has a listener)
+       * 2. Don't set any offsets against the first token of the node.
+       * 3. Call `ignoreNode` on the node sometime after exiting it and before
+       *    validating offsets.
+       */
+      const offsetListeners = lodash.mapValues(
+         baseOffsetListeners,
+
+         /*
+          * Offset listener calls are deferred until traversal is finished, and are
+          * called as part of the final `Program:exit` listener. This is necessary
+          * because a node might be matched by multiple selectors.
+          *
+          * Example: Suppose there is an offset listener for `Identifier`, and the user
+          * has specified in configuration that `MemberExpression > Identifier` should
+          * be ignored.  Due to selector specificity rules, the `Identifier` listener
+          * will get called first. However, if a given Identifier node is supposed to
+          * be ignored, then the `Identifier` offset listener should not have been
+          * called at all. Without doing extra selector matching, we don't know whether
+          * the Identifier matches the `MemberExpression > Identifier` selector until
+          * the `MemberExpression > Identifier` listener is called.
+          *
+          * To avoid this, the `Identifier` listener isn't called until traversal
+          * finishes and all ignored nodes are known.
+          */
+         (listener) => (node) => listenerCallQueue.push({ listener, node })
+      );
+
+      // For each ignored node selector, set up a listener to collect it into the
+      // `ignoredNodes` set.
+      const ignoredNodes = new Set();
+
+      /**
+       * Ignores a node
+       * @param {ASTNode} node The node to ignore
+       * @returns {void}
+       */
+      function addToIgnoredNodes(node) {
+         ignoredNodes.add(node);
+         ignoredNodeFirstTokens.add(sourceCode.getFirstToken(node));
+      }
+
+      const ignoredNodeListeners = options.ignoredNodes.reduce(
+         (listeners, ignoredSelector) => Object.assign(listeners, { [ignoredSelector]: addToIgnoredNodes }),
+         {}
+      );
+
+      /*
+       * Join the listeners, and add a listener to verify that all tokens actually have
+       * the correct indentation at the end.
+       *
+       * Using Object.assign will cause some offset listeners to be overwritten if the
+       * same selector also appears in `ignoredNodeListeners`. This isn't a problem
+       * because all of the matching nodes will be ignored, so those listeners wouldn't
+       * be called anyway.
+       */
+      return Object.assign(
+         offsetListeners,
+         ignoredNodeListeners,
+         {
+            '*:exit'(node) {
+
+                // If a node's type is nonstandard, we can't tell how its children should
+                // be offset, so ignore it.
+               if (!KNOWN_NODES.has(node.type)) {
+                  addToIgnoredNodes(node);
+               }
+            },
+            'Program:exit'() {
+
+                // If ignoreComments option is enabled, ignore all comment tokens.
+               if (options.ignoreComments) {
+                  sourceCode.getAllComments()
+                     .forEach((comment) => offsets.ignoreToken(comment));
+               }
+
+                // Invoke the queued offset listeners for the nodes that aren't ignored.
+               listenerCallQueue
+                  .filter((nodeInfo) => !ignoredNodes.has(nodeInfo.node))
+                  .forEach((nodeInfo) => nodeInfo.listener(nodeInfo.node));
+
+                // Update the offsets for ignored nodes to prevent their child tokens from
+                // being reported.
+               ignoredNodes.forEach(ignoreNode);
+
+               addParensIndent(sourceCode.ast.tokens);
+
+               /*
+                * Create a Map from (tokenOrComment) => (precedingToken).
+                * This is necessary because sourceCode.getTokenBefore does not
+                * handle a comment as an argument correctly.
+                */
+               const precedingTokens = sourceCode.ast.comments.reduce((commentMap, comment) => {
+                  const tokenOrCommentBefore = sourceCode.getTokenBefore(comment, { includeComments: true }),
+                        tokenBefore = commentMap.has(tokenOrCommentBefore) ? commentMap.get(tokenOrCommentBefore) : tokenOrCommentBefore;
+
+                  return commentMap.set(comment, tokenBefore);
+               }, new WeakMap());
+
+               sourceCode.lines.forEach((line, lineIndex) => {
+                  const lineNumber = lineIndex + 1;
+
+                  if (!tokenInfo.firstTokensByLineNumber.has(lineNumber)) {
+
+                     // Don't check indentation on blank lines
+                     return;
+                  }
+
+                  const firstTokenOfLine = tokenInfo.firstTokensByLineNumber.get(lineNumber);
+
+                  if (firstTokenOfLine.loc.start.line !== lineNumber) {
+
+                     // Don't check the indentation of multi-line tokens (e.g. template
+                     // literals or block comments) twice.
+                     return;
+                  }
+
+                  // If the token matches the expected expected indentation, don't report
+                  // it.
+                  if (validateTokenIndent(firstTokenOfLine, offsets.getDesiredIndent(firstTokenOfLine))) {
+                     return;
+                  }
+
+                  if (astUtils.isCommentToken(firstTokenOfLine)) {
+                     const tokenBefore = precedingTokens.get(firstTokenOfLine),
+                           tokenAfter = tokenBefore ? sourceCode.getTokenAfter(tokenBefore) : sourceCode.ast.tokens[0],
+                           mayAlignWithBefore = tokenBefore && !hasBlankLinesBetween(tokenBefore, firstTokenOfLine),
+                           mayAlignWithAfter = tokenAfter && !hasBlankLinesBetween(firstTokenOfLine, tokenAfter),
+                           validateTokenBefore = validateTokenIndent(firstTokenOfLine, offsets.getDesiredIndent(tokenBefore)),
+                           validateTokenAfter = validateTokenIndent(firstTokenOfLine, offsets.getDesiredIndent(tokenAfter));
+
+                     // If a comment matches the expected indentation of the token
+                     // immediately before or after, don't report it.
+                     if (mayAlignWithBefore && validateTokenBefore || mayAlignWithAfter && validateTokenAfter) {
+                        return;
+                     }
+                  }
+
+                  // Otherwise, report the token/comment.
+                  report(firstTokenOfLine, offsets.getDesiredIndent(firstTokenOfLine));
+               });
+            },
+         }
+      );
+   },
 };

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -363,10 +363,11 @@ class OffsetStorage {
     * @param {Token} token The token
     * @param {Token} fromToken The token that `token` should be offset from
     * @param {number} offset The desired indent level
+    * @param {number} extraIndent The extra static indent amount to add to desired offset
     * @returns {void}
     */
-   setDesiredOffset(token, fromToken, offset) {
-      return this.setDesiredOffsets(token.range, fromToken, offset);
+   setDesiredOffset(token, fromToken, offset, extraIndent) {
+      return this.setDesiredOffsets(token.range, fromToken, offset, extraIndent);
    }
 
    /**
@@ -404,9 +405,10 @@ class OffsetStorage {
     * @param {number} offset The desired indent level
     * @param {boolean} force `true` if this offset should not use the normal collapsing
     *                        behavior. This should almost always be false.
+    * @param {number} extraIndent The extra static indent amount to add to desired offset
     * @returns {void}
     */
-   setDesiredOffsets(range, fromToken, offset, force) {
+   setDesiredOffsets(range, fromToken, offset, force, extraIndent) {
 
       /*
        * Offset ranges are stored as a collection of nodes, where each node maps a
@@ -423,7 +425,7 @@ class OffsetStorage {
        * with the largest key which is <= token.start. To make this operation fast, the
        * nodes are stored in a balanced binary search tree indexed by key.
        */
-      const descriptorToInsert = { offset, from: fromToken, force };
+      const descriptorToInsert = { offset, from: fromToken, force, extraIndent };
 
       const descriptorAfterRange = this._tree.findLe(range[1]).value;
 
@@ -485,12 +487,14 @@ class OffsetStorage {
          } else {
             const offsetInfo = this._getOffsetDescriptor(token);
 
+            const extraIndent = offsetInfo.extraIndent ? offsetInfo.extraIndent : 0;
+
             const offset = (
                     offsetInfo.from &&
                     offsetInfo.from.loc.start.line === token.loc.start.line &&
                     !/^\s*?\n/.test(token.value) &&
                     !offsetInfo.force
-                ) ? 0 : offsetInfo.offset * this._indentSize;
+                ) ? 0 : offsetInfo.offset * this._indentSize + extraIndent;
 
             this._desiredIndentCache.set(
                token,
@@ -581,12 +585,38 @@ module.exports = {
                               type: 'number',
                               minimum: 0,
                            },
-                           let: {
+                           'let': {
                               type: 'number',
                               minimum: 0,
                            },
                            'const': {
                               type: 'number',
+                              minimum: 0,
+                           },
+                        },
+                        additionalProperties: false,
+                     },
+                  ],
+               },
+               VariableDeclaratorOffset: {
+                  oneOf: [
+                     {
+                        type: 'integer',
+                        minimum: 0,
+                     },
+                     {
+                        type: 'object',
+                        properties: {
+                           'var': {
+                              type: 'integer',
+                              minimum: 0,
+                           },
+                           'let': {
+                              type: 'integer',
+                              minimum: 0,
+                           },
+                           'const': {
+                              type: 'integer',
                               minimum: 0,
                            },
                         },
@@ -664,6 +694,7 @@ module.exports = {
 
    create(context) {
       const DEFAULT_VARIABLE_INDENT = 1,
+            DEFAULT_VARIABLE_STATIC_OFFSET = 0,
             DEFAULT_PARAMETER_INDENT = 1,
             DEFAULT_FUNCTION_BODY_INDENT = 1;
 
@@ -676,6 +707,11 @@ module.exports = {
             'var': DEFAULT_VARIABLE_INDENT,
             let: DEFAULT_VARIABLE_INDENT,
             'const': DEFAULT_VARIABLE_INDENT,
+         },
+         VariableDeclaratorOffset: {
+            'var': DEFAULT_VARIABLE_STATIC_OFFSET,
+            let: DEFAULT_VARIABLE_STATIC_OFFSET,
+            'const': DEFAULT_VARIABLE_STATIC_OFFSET,
          },
          outerIIFEBody: 1,
          FunctionDeclaration: {
@@ -715,6 +751,14 @@ module.exports = {
                   'var': options.VariableDeclarator,
                   let: options.VariableDeclarator,
                   'const': options.VariableDeclarator,
+               };
+            }
+
+            if (typeof options.VariableDeclaratorOffset === 'number') {
+               options.VariableDeclaratorOffset = {
+                  'var': options.VariableDeclaratorOffset,
+                  let: options.VariableDeclaratorOffset,
+                  'const': options.VariableDeclaratorOffset,
                };
             }
          }
@@ -1464,6 +1508,10 @@ module.exports = {
                     ? options.VariableDeclarator[node.kind]
                     : DEFAULT_VARIABLE_INDENT;
 
+            const extraVariableIndent = Object.prototype.hasOwnProperty.call(options.VariableDeclaratorOffset, node.kind)
+                    ? options.VariableDeclaratorOffset[node.kind]
+                    : 0;
+
             if (node.declarations[node.declarations.length - 1].loc.start.line > node.loc.start.line) {
 
                /*
@@ -1489,7 +1537,19 @@ module.exports = {
                 */
                const firstToken = sourceCode.getFirstToken(node);
 
-               offsets.setDesiredOffsets(node.range, firstToken, variableIndent, true);
+               offsets.setDesiredOffsets(node.range, firstToken, variableIndent, true, extraVariableIndent);
+            } else if (node.loc.start.line === node.loc.end.line) {
+
+               /* Only add the extra space if this declaration doesn't span multiple
+                * lines. Otherwise, we can't do:
+                * const myArr [
+                *    {
+                *       a: 1,
+                *       b: 2,
+                *    },
+                * ];
+                */
+               offsets.setDesiredOffsets(node.range, sourceCode.getFirstToken(node), variableIndent, extraVariableIndent);
             } else {
                offsets.setDesiredOffsets(node.range, sourceCode.getFirstToken(node), variableIndent);
             }

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -1,838 +1,1597 @@
 /**
-* Forked from: https://github.com/eslint/eslint/blob/v2.13.0/lib/rules/indent.js
-* This modification adds the `VariableDeclaratorOffset` configuration variable
-* that allows specifying how many spaces a multi-line variable declaration should
-* be offset from the normal indentation level. For example:
-*
-* var something,
-*     anotherSomething,
-*     somethingElse;
-*
-* The multi-line variable declaration is indented 4 spaces from the normal indentation
-* level, so VariableDeclaratorOffset should be set to '1' (i.e. indent of 3, offset adds
-* 1, total indent 4).  es6 const declarations would need an offset of 3 (indent of 3,
-* offset adds 3, total indent 6) to line up.
-*
-* Example configuration: "silvermine/indent":
-* [
-*    "error",
-*    3,
-*    {
-*       "VariableDeclaratorOffset": { "var": 1, "let": 1, "const": 3 },
-*       "SwitchCase": 1
-*    }
-* ]
-*
-*/
+ * @fileoverview This rule sets a specific indentation style and width for your code
+ *
+ * @author Teddy Katz
+ * @author Vitaly Puzrin
+ * @author Gyandeep Singh
+ */
 
-'use strict';
+"use strict";
 
-// ------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const lodash = require("lodash");
+const astUtils = require("../util/ast-utils");
+const createTree = require("functional-red-black-tree");
+
+//------------------------------------------------------------------------------
 // Rule Definition
-// ------------------------------------------------------------------------------
-var util = require('util'),
-    lodashAssign = require('lodash.assign'),
-    _ = require('underscore');
+//------------------------------------------------------------------------------
+
+const KNOWN_NODES = new Set([
+    "AssignmentExpression",
+    "AssignmentPattern",
+    "ArrayExpression",
+    "ArrayPattern",
+    "ArrowFunctionExpression",
+    "AwaitExpression",
+    "BlockStatement",
+    "BinaryExpression",
+    "BreakStatement",
+    "CallExpression",
+    "CatchClause",
+    "ClassBody",
+    "ClassDeclaration",
+    "ClassExpression",
+    "ConditionalExpression",
+    "ContinueStatement",
+    "DoWhileStatement",
+    "DebuggerStatement",
+    "EmptyStatement",
+    "ExperimentalRestProperty",
+    "ExperimentalSpreadProperty",
+    "ExpressionStatement",
+    "ForStatement",
+    "ForInStatement",
+    "ForOfStatement",
+    "FunctionDeclaration",
+    "FunctionExpression",
+    "Identifier",
+    "IfStatement",
+    "Literal",
+    "LabeledStatement",
+    "LogicalExpression",
+    "MemberExpression",
+    "MetaProperty",
+    "MethodDefinition",
+    "NewExpression",
+    "ObjectExpression",
+    "ObjectPattern",
+    "Program",
+    "Property",
+    "RestElement",
+    "ReturnStatement",
+    "SequenceExpression",
+    "SpreadElement",
+    "Super",
+    "SwitchCase",
+    "SwitchStatement",
+    "TaggedTemplateExpression",
+    "TemplateElement",
+    "TemplateLiteral",
+    "ThisExpression",
+    "ThrowStatement",
+    "TryStatement",
+    "UnaryExpression",
+    "UpdateExpression",
+    "VariableDeclaration",
+    "VariableDeclarator",
+    "WhileStatement",
+    "WithStatement",
+    "YieldExpression",
+    "JSXIdentifier",
+    "JSXNamespacedName",
+    "JSXMemberExpression",
+    "JSXEmptyExpression",
+    "JSXExpressionContainer",
+    "JSXElement",
+    "JSXClosingElement",
+    "JSXOpeningElement",
+    "JSXAttribute",
+    "JSXSpreadAttribute",
+    "JSXText",
+    "ExportDefaultDeclaration",
+    "ExportNamedDeclaration",
+    "ExportAllDeclaration",
+    "ExportSpecifier",
+    "ImportDeclaration",
+    "ImportSpecifier",
+    "ImportDefaultSpecifier",
+    "ImportNamespaceSpecifier"
+]);
+
+/*
+ * General rule strategy:
+ * 1. An OffsetStorage instance stores a map of desired offsets, where each token has a specified offset from another
+ *    specified token or to the first column.
+ * 2. As the AST is traversed, modify the desired offsets of tokens accordingly. For example, when entering a
+ *    BlockStatement, offset all of the tokens in the BlockStatement by 1 indent level from the opening curly
+ *    brace of the BlockStatement.
+ * 3. After traversing the AST, calculate the expected indentation levels of every token according to the
+ *    OffsetStorage container.
+ * 4. For each line, compare the expected indentation of the first token to the actual indentation in the file,
+ *    and report the token if the two values are not equal.
+ */
+
+
+/**
+ * A mutable balanced binary search tree that stores (key, value) pairs. The keys are numeric, and must be unique.
+ * This is intended to be a generic wrapper around a balanced binary search tree library, so that the underlying implementation
+ * can easily be swapped out.
+ */
+class BinarySearchTree {
+
+    /**
+     * Creates an empty tree
+     */
+    constructor() {
+        this._rbTree = createTree();
+    }
+
+    /**
+     * Inserts an entry into the tree.
+     * @param {number} key The entry's key
+     * @param {*} value The entry's value
+     * @returns {void}
+     */
+    insert(key, value) {
+        const iterator = this._rbTree.find(key);
+
+        if (iterator.valid) {
+            this._rbTree = iterator.update(value);
+        } else {
+            this._rbTree = this._rbTree.insert(key, value);
+        }
+    }
+
+    /**
+     * Finds the entry with the largest key less than or equal to the provided key
+     * @param {number} key The provided key
+     * @returns {{key: number, value: *}|null} The found entry, or null if no such entry exists.
+     */
+    findLe(key) {
+        const iterator = this._rbTree.le(key);
+
+        return iterator && { key: iterator.key, value: iterator.value };
+    }
+
+    /**
+     * Deletes all of the keys in the interval [start, end)
+     * @param {number} start The start of the range
+     * @param {number} end The end of the range
+     * @returns {void}
+     */
+    deleteRange(start, end) {
+
+        // Exit without traversing the tree if the range has zero size.
+        if (start === end) {
+            return;
+        }
+        const iterator = this._rbTree.ge(start);
+
+        while (iterator.valid && iterator.key < end) {
+            this._rbTree = this._rbTree.remove(iterator.key);
+            iterator.next();
+        }
+    }
+}
+
+/**
+ * A helper class to get token-based info related to indentation
+ */
+class TokenInfo {
+
+    /**
+     * @param {SourceCode} sourceCode A SourceCode object
+     */
+    constructor(sourceCode) {
+        this.sourceCode = sourceCode;
+        this.firstTokensByLineNumber = sourceCode.tokensAndComments.reduce((map, token) => {
+            if (!map.has(token.loc.start.line)) {
+                map.set(token.loc.start.line, token);
+            }
+            if (!map.has(token.loc.end.line) && sourceCode.text.slice(token.range[1] - token.loc.end.column, token.range[1]).trim()) {
+                map.set(token.loc.end.line, token);
+            }
+            return map;
+        }, new Map());
+    }
+
+    /**
+     * Gets the first token on a given token's line
+     * @param {Token|ASTNode} token a node or token
+     * @returns {Token} The first token on the given line
+     */
+    getFirstTokenOfLine(token) {
+        return this.firstTokensByLineNumber.get(token.loc.start.line);
+    }
+
+    /**
+     * Determines whether a token is the first token in its line
+     * @param {Token} token The token
+     * @returns {boolean} `true` if the token is the first on its line
+     */
+    isFirstTokenOfLine(token) {
+        return this.getFirstTokenOfLine(token) === token;
+    }
+
+    /**
+     * Get the actual indent of a token
+     * @param {Token} token Token to examine. This should be the first token on its line.
+     * @returns {string} The indentation characters that precede the token
+     */
+    getTokenIndent(token) {
+        return this.sourceCode.text.slice(token.range[0] - token.loc.start.column, token.range[0]);
+    }
+}
+
+/**
+ * A class to store information on desired offsets of tokens from each other
+ */
+class OffsetStorage {
+
+    /**
+     * @param {TokenInfo} tokenInfo a TokenInfo instance
+     * @param {number} indentSize The desired size of each indentation level
+     * @param {string} indentType The indentation character
+     */
+    constructor(tokenInfo, indentSize, indentType) {
+        this._tokenInfo = tokenInfo;
+        this._indentSize = indentSize;
+        this._indentType = indentType;
+
+        this._tree = new BinarySearchTree();
+        this._tree.insert(0, { offset: 0, from: null, force: false });
+
+        this._lockedFirstTokens = new WeakMap();
+        this._desiredIndentCache = new WeakMap();
+        this._ignoredTokens = new WeakSet();
+    }
+
+    _getOffsetDescriptor(token) {
+        return this._tree.findLe(token.range[0]).value;
+    }
+
+    /**
+     * Sets the offset column of token B to match the offset column of token A.
+     * **WARNING**: This matches a *column*, even if baseToken is not the first token on its line. In
+     * most cases, `setDesiredOffset` should be used instead.
+     * @param {Token} baseToken The first token
+     * @param {Token} offsetToken The second token, whose offset should be matched to the first token
+     * @returns {void}
+     */
+    matchOffsetOf(baseToken, offsetToken) {
+
+        /*
+         * lockedFirstTokens is a map from a token whose indentation is controlled by the "first" option to
+         * the token that it depends on. For example, with the `ArrayExpression: first` option, the first
+         * token of each element in the array after the first will be mapped to the first token of the first
+         * element. The desired indentation of each of these tokens is computed based on the desired indentation
+         * of the "first" element, rather than through the normal offset mechanism.
+         */
+        this._lockedFirstTokens.set(offsetToken, baseToken);
+    }
+
+    /**
+     * Sets the desired offset of a token.
+     *
+     * This uses a line-based offset collapsing behavior to handle tokens on the same line.
+     * For example, consider the following two cases:
+     *
+     * (
+     *     [
+     *         bar
+     *     ]
+     * )
+     *
+     * ([
+     *     bar
+     * ])
+     *
+     * Based on the first case, it's clear that the `bar` token needs to have an offset of 1 indent level (4 spaces) from
+     * the `[` token, and the `[` token has to have an offset of 1 indent level from the `(` token. Since the `(` token is
+     * the first on its line (with an indent of 0 spaces), the `bar` token needs to be offset by 2 indent levels (8 spaces)
+     * from the start of its line.
+     *
+     * However, in the second case `bar` should only be indented by 4 spaces. This is because the offset of 1 indent level
+     * between the `(` and the `[` tokens gets "collapsed" because the two tokens are on the same line. As a result, the
+     * `(` token is mapped to the `[` token with an offset of 0, and the rule correctly decides that `bar` should be indented
+     * by 1 indent level from the start of the line.
+     *
+     * This is useful because rule listeners can usually just call `setDesiredOffset` for all the tokens in the node,
+     * without needing to check which lines those tokens are on.
+     *
+     * Note that since collapsing only occurs when two tokens are on the same line, there are a few cases where non-intuitive
+     * behavior can occur. For example, consider the following cases:
+     *
+     * foo(
+     * ).
+     *     bar(
+     *         baz
+     *     )
+     *
+     * foo(
+     * ).bar(
+     *     baz
+     * )
+     *
+     * Based on the first example, it would seem that `bar` should be offset by 1 indent level from `foo`, and `baz`
+     * should be offset by 1 indent level from `bar`. However, this is not correct, because it would result in `baz`
+     * being indented by 2 indent levels in the second case (since `foo`, `bar`, and `baz` are all on separate lines, no
+     * collapsing would occur).
+     *
+     * Instead, the correct way would be to offset `baz` by 1 level from `bar`, offset `bar` by 1 level from the `)`, and
+     * offset the `)` by 0 levels from `foo`. This ensures that the offset between `bar` and the `)` are correctly collapsed
+     * in the second case.
+     *
+     * @param {Token} token The token
+     * @param {Token} fromToken The token that `token` should be offset from
+     * @param {number} offset The desired indent level
+     * @returns {void}
+     */
+    setDesiredOffset(token, fromToken, offset) {
+        return this.setDesiredOffsets(token.range, fromToken, offset);
+    }
+
+    /**
+     * Sets the desired offset of all tokens in a range
+     * It's common for node listeners in this file to need to apply the same offset to a large, contiguous range of tokens.
+     * Moreover, the offset of any given token is usually updated multiple times (roughly once for each node that contains
+     * it). This means that the offset of each token is updated O(AST depth) times.
+     * It would not be performant to store and update the offsets for each token independently, because the rule would end
+     * up having a time complexity of O(number of tokens * AST depth), which is quite slow for large files.
+     *
+     * Instead, the offset tree is represented as a collection of contiguous offset ranges in a file. For example, the following
+     * list could represent the state of the offset tree at a given point:
+     *
+     * * Tokens starting in the interval [0, 15) are aligned with the beginning of the file
+     * * Tokens starting in the interval [15, 30) are offset by 1 indent level from the `bar` token
+     * * Tokens starting in the interval [30, 43) are offset by 1 indent level from the `foo` token
+     * * Tokens starting in the interval [43, 820) are offset by 2 indent levels from the `bar` token
+     * * Tokens starting in the interval [820, ∞) are offset by 1 indent level from the `baz` token
+     *
+     * The `setDesiredOffsets` methods inserts ranges like the ones above. The third line above would be inserted by using:
+     * `setDesiredOffsets([30, 43], fooToken, 1);`
+     *
+     * @param {[number, number]} range A [start, end] pair. All tokens with range[0] <= token.start < range[1] will have the offset applied.
+     * @param {Token} fromToken The token that this is offset from
+     * @param {number} offset The desired indent level
+     * @param {boolean} force `true` if this offset should not use the normal collapsing behavior. This should almost always be false.
+     * @returns {void}
+     */
+    setDesiredOffsets(range, fromToken, offset, force) {
+
+        /*
+         * Offset ranges are stored as a collection of nodes, where each node maps a numeric key to an offset
+         * descriptor. The tree for the example above would have the following nodes:
+         *
+         * * key: 0, value: { offset: 0, from: null }
+         * * key: 15, value: { offset: 1, from: barToken }
+         * * key: 30, value: { offset: 1, from: fooToken }
+         * * key: 43, value: { offset: 2, from: barToken }
+         * * key: 820, value: { offset: 1, from: bazToken }
+         *
+         * To find the offset descriptor for any given token, one needs to find the node with the largest key
+         * which is <= token.start. To make this operation fast, the nodes are stored in a balanced binary
+         * search tree indexed by key.
+         */
+
+        const descriptorToInsert = { offset, from: fromToken, force };
+
+        const descriptorAfterRange = this._tree.findLe(range[1]).value;
+
+        const fromTokenIsInRange = fromToken && fromToken.range[0] >= range[0] && fromToken.range[1] <= range[1];
+        const fromTokenDescriptor = fromTokenIsInRange && this._getOffsetDescriptor(fromToken);
+
+        // First, remove any existing nodes in the range from the tree.
+        this._tree.deleteRange(range[0] + 1, range[1]);
+
+        // Insert a new node into the tree for this range
+        this._tree.insert(range[0], descriptorToInsert);
+
+        /*
+         * To avoid circular offset dependencies, keep the `fromToken` token mapped to whatever it was mapped to previously,
+         * even if it's in the current range.
+         */
+        if (fromTokenIsInRange) {
+            this._tree.insert(fromToken.range[0], fromTokenDescriptor);
+            this._tree.insert(fromToken.range[1], descriptorToInsert);
+        }
+
+        /*
+         * To avoid modifying the offset of tokens after the range, insert another node to keep the offset of the following
+         * tokens the same as it was before.
+         */
+        this._tree.insert(range[1], descriptorAfterRange);
+    }
+
+    /**
+     * Gets the desired indent of a token
+     * @param {Token} token The token
+     * @returns {string} The desired indent of the token
+     */
+    getDesiredIndent(token) {
+        if (!this._desiredIndentCache.has(token)) {
+
+            if (this._ignoredTokens.has(token)) {
+
+                /*
+                 * If the token is ignored, use the actual indent of the token as the desired indent.
+                 * This ensures that no errors are reported for this token.
+                 */
+                this._desiredIndentCache.set(
+                    token,
+                    this._tokenInfo.getTokenIndent(token)
+                );
+            } else if (this._lockedFirstTokens.has(token)) {
+                const firstToken = this._lockedFirstTokens.get(token);
+
+                this._desiredIndentCache.set(
+                    token,
+
+                    // (indentation for the first element's line)
+                    this.getDesiredIndent(this._tokenInfo.getFirstTokenOfLine(firstToken)) +
+
+                        // (space between the start of the first element's line and the first element)
+                        this._indentType.repeat(firstToken.loc.start.column - this._tokenInfo.getFirstTokenOfLine(firstToken).loc.start.column)
+                );
+            } else {
+                const offsetInfo = this._getOffsetDescriptor(token);
+                const offset = (
+                    offsetInfo.from &&
+                    offsetInfo.from.loc.start.line === token.loc.start.line &&
+                    !/^\s*?\n/.test(token.value) &&
+                    !offsetInfo.force
+                ) ? 0 : offsetInfo.offset * this._indentSize;
+
+                this._desiredIndentCache.set(
+                    token,
+                    (offsetInfo.from ? this.getDesiredIndent(offsetInfo.from) : "") + this._indentType.repeat(offset)
+                );
+            }
+        }
+        return this._desiredIndentCache.get(token);
+    }
+
+    /**
+     * Ignores a token, preventing it from being reported.
+     * @param {Token} token The token
+     * @returns {void}
+     */
+    ignoreToken(token) {
+        if (this._tokenInfo.isFirstTokenOfLine(token)) {
+            this._ignoredTokens.add(token);
+        }
+    }
+
+    /**
+     * Gets the first token that the given token's indentation is dependent on
+     * @param {Token} token The token
+     * @returns {Token} The token that the given token depends on, or `null` if the given token is at the top level
+     */
+    getFirstDependency(token) {
+        return this._getOffsetDescriptor(token).from;
+    }
+}
+
+const ELEMENT_LIST_SCHEMA = {
+    oneOf: [
+        {
+            type: "integer",
+            minimum: 0
+        },
+        {
+            enum: ["first", "off"]
+        }
+    ]
+};
 
 module.exports = {
-   meta: {
-      docs: {
-         description: 'enforce consistent indentation',
-         category: 'Stylistic Issues',
-         recommended: false,
-      },
+    meta: {
+        type: "layout",
 
-      fixable: 'whitespace',
+        docs: {
+            description: "enforce consistent indentation",
+            category: "Stylistic Issues",
+            recommended: false,
+            url: "https://eslint.org/docs/rules/indent"
+        },
 
-      schema: [
-         {
-            oneOf: [
-               {
-                  'enum': [ 'tab' ],
-               },
-               {
-                  type: 'integer',
-                  minimum: 0,
-               },
-            ],
-         },
-         {
-            type: 'object',
-            properties: {
-               SwitchCase: {
-                  type: 'integer',
-                  minimum: 0,
-               },
-               VariableDeclarator: {
-                  oneOf: [
-                     {
-                        type: 'integer',
-                        minimum: 0,
-                     },
-                     {
-                        type: 'object',
-                        properties: {
-                           'var': {
-                              type: 'integer',
-                              minimum: 0,
-                           },
-                           'let': {
-                              type: 'integer',
-                              minimum: 0,
-                           },
-                           'const': {
-                              type: 'integer',
-                              minimum: 0,
-                           },
-                        },
-                     },
-                  ],
-               },
-               VariableDeclaratorOffset: {
-                  oneOf: [
-                     {
-                        type: 'integer',
-                        minimum: Number.MIN_VALUE,
-                     },
-                     {
-                        type: 'object',
-                        properties: {
-                           'var': {
-                              type: 'integer',
-                              minimum: Number.MIN_VALUE,
-                           },
-                           'let': {
-                              type: 'integer',
-                              minimum: Number.MIN_VALUE,
-                           },
-                           'const': {
-                              type: 'integer',
-                              minimum: Number.MIN_VALUE,
-                           },
-                        },
-                     },
-                  ],
-               },
+        fixable: "whitespace",
+
+        schema: [
+            {
+                oneOf: [
+                    {
+                        enum: ["tab"]
+                    },
+                    {
+                        type: "integer",
+                        minimum: 0
+                    }
+                ]
             },
-            additionalProperties: false,
-         },
-      ],
-   },
-
-   create: function(context) {
-
-      var MESSAGE = 'Expected indentation of {{needed}} {{type}} {{characters}} but found {{gotten}}.',
-          DEFAULT_VARIABLE_INDENT = 1,
-          DEFAULT_VARIABLE_INDENT_OFFSET = 0,
-          indentType = 'space',
-          indentSize = 4,
-          sourceCode = context.getSourceCode(),
-          options, opts, variableDeclaratorRules, variableDeclaratorOffsetRules, indentPattern, caseIndentStore;
-
-      options = {
-         SwitchCase: 0,
-         VariableDeclarator: {
-            'var': DEFAULT_VARIABLE_INDENT,
-            'let': DEFAULT_VARIABLE_INDENT,
-            'const': DEFAULT_VARIABLE_INDENT,
-         },
-         VariableDeclaratorOffset: {
-            'var': DEFAULT_VARIABLE_INDENT_OFFSET,
-            'let': DEFAULT_VARIABLE_INDENT_OFFSET,
-            'const': DEFAULT_VARIABLE_INDENT_OFFSET,
-         },
-      };
-
-
-      if (context.options.length) {
-         if (context.options[0] === 'tab') {
-            indentSize = 1;
-            indentType = 'tab';
-         } else /* istanbul ignore else : this will be caught by options validation */ if (typeof context.options[0] === 'number') {
-            indentSize = context.options[0];
-            indentType = 'space';
-         }
-
-         if (context.options[1]) {
-            opts = context.options[1];
-
-            options.SwitchCase = opts.SwitchCase || 0;
-            variableDeclaratorRules = opts.VariableDeclarator;
-
-            if (typeof variableDeclaratorRules === 'number') {
-               options.VariableDeclarator = {
-                  'var': variableDeclaratorRules,
-                  'let': variableDeclaratorRules,
-                  'const': variableDeclaratorRules,
-               };
-            } else if (typeof variableDeclaratorRules === 'object') {
-               lodashAssign(options.VariableDeclarator, variableDeclaratorRules);
+            {
+                type: "object",
+                properties: {
+                    SwitchCase: {
+                        type: "integer",
+                        minimum: 0
+                    },
+                    VariableDeclarator: {
+                        oneOf: [
+                            {
+                                type: "integer",
+                                minimum: 0
+                            },
+                            {
+                                type: "object",
+                                properties: {
+                                    var: {
+                                        type: "integer",
+                                        minimum: 0
+                                    },
+                                    let: {
+                                        type: "integer",
+                                        minimum: 0
+                                    },
+                                    const: {
+                                        type: "integer",
+                                        minimum: 0
+                                    }
+                                },
+                                additionalProperties: false
+                            }
+                        ]
+                    },
+                    outerIIFEBody: {
+                        type: "integer",
+                        minimum: 0
+                    },
+                    MemberExpression: {
+                        oneOf: [
+                            {
+                                type: "integer",
+                                minimum: 0
+                            },
+                            {
+                                enum: ["off"]
+                            }
+                        ]
+                    },
+                    FunctionDeclaration: {
+                        type: "object",
+                        properties: {
+                            parameters: ELEMENT_LIST_SCHEMA,
+                            body: {
+                                type: "integer",
+                                minimum: 0
+                            }
+                        },
+                        additionalProperties: false
+                    },
+                    FunctionExpression: {
+                        type: "object",
+                        properties: {
+                            parameters: ELEMENT_LIST_SCHEMA,
+                            body: {
+                                type: "integer",
+                                minimum: 0
+                            }
+                        },
+                        additionalProperties: false
+                    },
+                    CallExpression: {
+                        type: "object",
+                        properties: {
+                            arguments: ELEMENT_LIST_SCHEMA
+                        },
+                        additionalProperties: false
+                    },
+                    ArrayExpression: ELEMENT_LIST_SCHEMA,
+                    ObjectExpression: ELEMENT_LIST_SCHEMA,
+                    ImportDeclaration: ELEMENT_LIST_SCHEMA,
+                    flatTernaryExpressions: {
+                        type: "boolean"
+                    },
+                    ignoredNodes: {
+                        type: "array",
+                        items: {
+                            type: "string",
+                            not: {
+                                pattern: ":exit$"
+                            }
+                        }
+                    },
+                    ignoreComments: {
+                        type: "boolean"
+                    }
+                },
+                additionalProperties: false
             }
+        ]
+    },
 
-            variableDeclaratorOffsetRules = opts.VariableDeclaratorOffset;
+    create(context) {
+        const DEFAULT_VARIABLE_INDENT = 1;
+        const DEFAULT_PARAMETER_INDENT = 1;
+        const DEFAULT_FUNCTION_BODY_INDENT = 1;
 
-            if (typeof variableDeclaratorOffsetRules === 'number') {
-               options.VariableDeclaratorOffset = {
-                  'var': variableDeclaratorOffsetRules,
-                  'let': variableDeclaratorOffsetRules,
-                  'const': variableDeclaratorOffsetRules,
-               };
-            } else if (typeof variableDeclaratorOffsetRules === 'object') {
-               lodashAssign(options.VariableDeclaratorOffset, variableDeclaratorOffsetRules);
-            }
-         }
-      }
+        let indentType = "space";
+        let indentSize = 4;
+        const options = {
+            SwitchCase: 0,
+            VariableDeclarator: {
+                var: DEFAULT_VARIABLE_INDENT,
+                let: DEFAULT_VARIABLE_INDENT,
+                const: DEFAULT_VARIABLE_INDENT
+            },
+            outerIIFEBody: 1,
+            FunctionDeclaration: {
+                parameters: DEFAULT_PARAMETER_INDENT,
+                body: DEFAULT_FUNCTION_BODY_INDENT
+            },
+            FunctionExpression: {
+                parameters: DEFAULT_PARAMETER_INDENT,
+                body: DEFAULT_FUNCTION_BODY_INDENT
+            },
+            CallExpression: {
+                arguments: DEFAULT_PARAMETER_INDENT
+            },
+            MemberExpression: 1,
+            ArrayExpression: 1,
+            ObjectExpression: 1,
+            ImportDeclaration: 1,
+            flatTernaryExpressions: false,
+            ignoredNodes: [],
+            ignoreComments: false
+        };
 
-      indentPattern = {
-         normal: indentType === 'space' ? /^ +/ : /^\t+/,
-         excludeCommas: indentType === 'space' ? /^[ ,]+/ : /^[\t,]+/,
-      };
-
-      caseIndentStore = {};
-
-      /**
-      * Reports a given indent violation and properly pluralizes the message
-      * @param {ASTNode} node Node violating the indent rule
-      * @param {int} needed Expected indentation character count
-      * @param {int} gotten Indentation character count in the actual node/code
-      * @param {Object=} loc Error line and column location
-      * @param {boolean} isLastNodeCheck Is the error for last node check
-      * @returns {void}
-      */
-      function report(node, needed, gotten, loc, isLastNodeCheck) {
-         var msgContext, indentChar;
-
-         msgContext = {
-            needed: needed,
-            type: indentType,
-            characters: needed === 1 ? 'character' : 'characters',
-            gotten: gotten,
-         };
-         indentChar = indentType === 'space' ? ' ' : '\t';
-
-         /**
-         * Responsible for fixing the indentation issue fix
-         * @returns {Function} function to be executed by the fixer
-         * @private
-         */
-         function getFixerFunction() {
-            var rangeToFix = [],
-                spaces;
-
-            if (needed > gotten) {
-               spaces = String(new Array(needed - gotten + 1).join(indentChar)); // replace with repeat in future
-
-               if (isLastNodeCheck === true) {
-                  rangeToFix = [
-                     node.range[1] - 1,
-                     node.range[1] - 1,
-                  ];
-               } else {
-                  rangeToFix = [
-                     node.range[0],
-                     node.range[0],
-                  ];
-               }
-
-               return function(fixer) {
-                  return fixer.insertTextBeforeRange(rangeToFix, spaces);
-               };
-            }
-
-            if (isLastNodeCheck === true) {
-               rangeToFix = [
-                  node.range[1] - (gotten - needed) - 1,
-                  node.range[1] - 1,
-               ];
+        if (context.options.length) {
+            if (context.options[0] === "tab") {
+                indentSize = 1;
+                indentType = "tab";
             } else {
-               rangeToFix = [
-                  node.range[0] - (gotten - needed),
-                  node.range[0],
-               ];
+                indentSize = context.options[0];
+                indentType = "space";
             }
 
-            return function(fixer) {
-               return fixer.removeRange(rangeToFix);
-            };
-         }
+            if (context.options[1]) {
+                lodash.merge(options, context.options[1]);
 
-         if (loc) {
+                if (typeof options.VariableDeclarator === "number") {
+                    options.VariableDeclarator = {
+                        var: options.VariableDeclarator,
+                        let: options.VariableDeclarator,
+                        const: options.VariableDeclarator
+                    };
+                }
+            }
+        }
+
+        const sourceCode = context.getSourceCode();
+        const tokenInfo = new TokenInfo(sourceCode);
+        const offsets = new OffsetStorage(tokenInfo, indentSize, indentType === "space" ? " " : "\t");
+        const parameterParens = new WeakSet();
+
+        /**
+         * Creates an error message for a line, given the expected/actual indentation.
+         * @param {int} expectedAmount The expected amount of indentation characters for this line
+         * @param {int} actualSpaces The actual number of indentation spaces that were found on this line
+         * @param {int} actualTabs The actual number of indentation tabs that were found on this line
+         * @returns {string} An error message for this line
+         */
+        function createErrorMessage(expectedAmount, actualSpaces, actualTabs) {
+            const expectedStatement = `${expectedAmount} ${indentType}${expectedAmount === 1 ? "" : "s"}`; // e.g. "2 tabs"
+            const foundSpacesWord = `space${actualSpaces === 1 ? "" : "s"}`; // e.g. "space"
+            const foundTabsWord = `tab${actualTabs === 1 ? "" : "s"}`; // e.g. "tabs"
+            let foundStatement;
+
+            if (actualSpaces > 0) {
+
+                /*
+                 * Abbreviate the message if the expected indentation is also spaces.
+                 * e.g. 'Expected 4 spaces but found 2' rather than 'Expected 4 spaces but found 2 spaces'
+                 */
+                foundStatement = indentType === "space" ? actualSpaces : `${actualSpaces} ${foundSpacesWord}`;
+            } else if (actualTabs > 0) {
+                foundStatement = indentType === "tab" ? actualTabs : `${actualTabs} ${foundTabsWord}`;
+            } else {
+                foundStatement = "0";
+            }
+
+            return `Expected indentation of ${expectedStatement} but found ${foundStatement}.`;
+        }
+
+        /**
+         * Reports a given indent violation
+         * @param {Token} token Token violating the indent rule
+         * @param {string} neededIndent Expected indentation string
+         * @returns {void}
+         */
+        function report(token, neededIndent) {
+            const actualIndent = Array.from(tokenInfo.getTokenIndent(token));
+            const numSpaces = actualIndent.filter(char => char === " ").length;
+            const numTabs = actualIndent.filter(char => char === "\t").length;
+
             context.report({
-               node: node,
-               loc: loc,
-               message: MESSAGE,
-               data: msgContext,
-               fix: getFixerFunction(),
+                node: token,
+                message: createErrorMessage(neededIndent.length, numSpaces, numTabs),
+                loc: {
+                    start: { line: token.loc.start.line, column: 0 },
+                    end: { line: token.loc.start.line, column: token.loc.start.column }
+                },
+                fix(fixer) {
+                    const range = [token.range[0] - token.loc.start.column, token.range[0]];
+                    const newText = neededIndent;
+
+                    return fixer.replaceTextRange(range, newText);
+                }
             });
-         } else {
-            context.report({
-               node: node,
-               message: MESSAGE,
-               data: msgContext,
-               fix: getFixerFunction(),
+        }
+
+        /**
+         * Checks if a token's indentation is correct
+         * @param {Token} token Token to examine
+         * @param {string} desiredIndent Desired indentation of the string
+         * @returns {boolean} `true` if the token's indentation is correct
+         */
+        function validateTokenIndent(token, desiredIndent) {
+            const indentation = tokenInfo.getTokenIndent(token);
+
+            return indentation === desiredIndent ||
+
+                // To avoid conflicts with no-mixed-spaces-and-tabs, don't report mixed spaces and tabs.
+                indentation.includes(" ") && indentation.includes("\t");
+        }
+
+        /**
+         * Check to see if the node is a file level IIFE
+         * @param {ASTNode} node The function node to check.
+         * @returns {boolean} True if the node is the outer IIFE
+         */
+        function isOuterIIFE(node) {
+
+            /*
+             * Verify that the node is an IIFE
+             */
+            if (!node.parent || node.parent.type !== "CallExpression" || node.parent.callee !== node) {
+                return false;
+            }
+
+            /*
+             * Navigate legal ancestors to determine whether this IIFE is outer.
+             * A "legal ancestor" is an expression or statement that causes the function to get executed immediately.
+             * For example, `!(function(){})()` is an outer IIFE even though it is preceded by a ! operator.
+             */
+            let statement = node.parent && node.parent.parent;
+
+            while (
+                statement.type === "UnaryExpression" && ["!", "~", "+", "-"].indexOf(statement.operator) > -1 ||
+                statement.type === "AssignmentExpression" ||
+                statement.type === "LogicalExpression" ||
+                statement.type === "SequenceExpression" ||
+                statement.type === "VariableDeclarator"
+            ) {
+                statement = statement.parent;
+            }
+
+            return (statement.type === "ExpressionStatement" || statement.type === "VariableDeclaration") && statement.parent.type === "Program";
+        }
+
+        /**
+         * Counts the number of linebreaks that follow the last non-whitespace character in a string
+         * @param {string} string The string to check
+         * @returns {number} The number of JavaScript linebreaks that follow the last non-whitespace character,
+         * or the total number of linebreaks if the string is all whitespace.
+         */
+        function countTrailingLinebreaks(string) {
+            const trailingWhitespace = string.match(/\s*$/)[0];
+            const linebreakMatches = trailingWhitespace.match(astUtils.createGlobalLinebreakMatcher());
+
+            return linebreakMatches === null ? 0 : linebreakMatches.length;
+        }
+
+        /**
+         * Check indentation for lists of elements (arrays, objects, function params)
+         * @param {ASTNode[]} elements List of elements that should be offset
+         * @param {Token} startToken The start token of the list that element should be aligned against, e.g. '['
+         * @param {Token} endToken The end token of the list, e.g. ']'
+         * @param {number|string} offset The amount that the elements should be offset
+         * @returns {void}
+         */
+        function addElementListIndent(elements, startToken, endToken, offset) {
+
+            /**
+             * Gets the first token of a given element, including surrounding parentheses.
+             * @param {ASTNode} element A node in the `elements` list
+             * @returns {Token} The first token of this element
+             */
+            function getFirstToken(element) {
+                let token = sourceCode.getTokenBefore(element);
+
+                while (astUtils.isOpeningParenToken(token) && token !== startToken) {
+                    token = sourceCode.getTokenBefore(token);
+                }
+                return sourceCode.getTokenAfter(token);
+            }
+
+            // Run through all the tokens in the list, and offset them by one indent level (mainly for comments, other things will end up overridden)
+            offsets.setDesiredOffsets(
+                [startToken.range[1], endToken.range[0]],
+                startToken,
+                typeof offset === "number" ? offset : 1
+            );
+            offsets.setDesiredOffset(endToken, startToken, 0);
+
+            // If the preference is "first" but there is no first element (e.g. sparse arrays w/ empty first slot), fall back to 1 level.
+            if (offset === "first" && elements.length && !elements[0]) {
+                return;
+            }
+            elements.forEach((element, index) => {
+                if (!element) {
+
+                    // Skip holes in arrays
+                    return;
+                }
+                if (offset === "off") {
+
+                    // Ignore the first token of every element if the "off" option is used
+                    offsets.ignoreToken(getFirstToken(element));
+                }
+
+                // Offset the following elements correctly relative to the first element
+                if (index === 0) {
+                    return;
+                }
+                if (offset === "first" && tokenInfo.isFirstTokenOfLine(getFirstToken(element))) {
+                    offsets.matchOffsetOf(getFirstToken(elements[0]), getFirstToken(element));
+                } else {
+                    const previousElement = elements[index - 1];
+                    const firstTokenOfPreviousElement = previousElement && getFirstToken(previousElement);
+                    const previousElementLastToken = previousElement && sourceCode.getLastToken(previousElement);
+
+                    if (
+                        previousElement &&
+                        previousElementLastToken.loc.end.line - countTrailingLinebreaks(previousElementLastToken.value) > startToken.loc.end.line
+                    ) {
+                        offsets.setDesiredOffsets(
+                            [previousElement.range[1], element.range[1]],
+                            firstTokenOfPreviousElement,
+                            0
+                        );
+                    }
+                }
             });
-         }
-      }
+        }
 
-      /**
-      * Get node indent
-      * @param {ASTNode|Token} node Node to examine
-      * @param {boolean} [byLastLine=false] get indent of node's last line
-      * @param {boolean} [excludeCommas=false] skip comma on start of line
-      * @returns {int} Indent
-      */
-      function getNodeIndent(node, byLastLine, excludeCommas) {
-         var token = byLastLine ? sourceCode.getLastToken(node) : sourceCode.getFirstToken(node),
-             src = sourceCode.getText(token, token.loc.start.column),
-             regExp = excludeCommas ? indentPattern.excludeCommas : indentPattern.normal,
-             indent = regExp.exec(src);
+        /**
+         * Check and decide whether to check for indentation for blockless nodes
+         * Scenarios are for or while statements without braces around them
+         * @param {ASTNode} node node to examine
+         * @returns {void}
+         */
+        function addBlocklessNodeIndent(node) {
+            if (node.type !== "BlockStatement") {
+                const lastParentToken = sourceCode.getTokenBefore(node, astUtils.isNotOpeningParenToken);
 
-         return indent ? indent[0].length : 0;
-      }
+                let firstBodyToken = sourceCode.getFirstToken(node);
+                let lastBodyToken = sourceCode.getLastToken(node);
 
-      /**
-      * Checks node is the first in its own start line. By default it looks by start line.
-      * @param {ASTNode} node The node to check
-      * @param {boolean} [byEndLocation=false] Lookup based on start position or end
-      * @returns {boolean} true if its the first in the its start line
-      */
-      function isNodeFirstInLine(node, byEndLocation) {
-         var firstToken = byEndLocation === true ? sourceCode.getLastToken(node, 1) : sourceCode.getTokenBefore(node),
-             startLine = byEndLocation === true ? node.loc.end.line : node.loc.start.line,
-             endLine = firstToken ? firstToken.loc.end.line : -1;
+                while (
+                    astUtils.isOpeningParenToken(sourceCode.getTokenBefore(firstBodyToken)) &&
+                    astUtils.isClosingParenToken(sourceCode.getTokenAfter(lastBodyToken))
+                ) {
+                    firstBodyToken = sourceCode.getTokenBefore(firstBodyToken);
+                    lastBodyToken = sourceCode.getTokenAfter(lastBodyToken);
+                }
 
-         return startLine !== endLine;
-      }
+                offsets.setDesiredOffsets([firstBodyToken.range[0], lastBodyToken.range[1]], lastParentToken, 1);
 
-      /**
-      * Check indent for node
-      * @param {ASTNode} node Node to check
-      * @param {int} indent needed indent
-      * @param {boolean} [excludeCommas=false] skip comma on start of line
-      * @returns {void}
-      */
-      function checkNodeIndent(node, indent, excludeCommas) {
-         var nodeIndent = getNodeIndent(node, false, excludeCommas);
+                /*
+                 * For blockless nodes with semicolon-first style, don't indent the semicolon.
+                 * e.g.
+                 * if (foo) bar()
+                 * ; [1, 2, 3].map(foo)
+                 */
+                const lastToken = sourceCode.getLastToken(node);
 
-         if (node.type !== 'ArrayExpression' && node.type !== 'ObjectExpression' && nodeIndent !== indent && isNodeFirstInLine(node)) {
-            report(node, indent, nodeIndent);
-         }
-      }
-
-      /**
-      * Check indent for nodes list
-      * @param {ASTNode[]} nodes list of node objects
-      * @param {int} indent needed indent
-      * @param {boolean} [excludeCommas=false] skip comma on start of line
-      * @returns {void}
-      */
-      function checkNodesIndent(nodes, indent, excludeCommas) {
-         nodes.forEach(function(node) {
-            var elseToken;
-
-            if (node.type === 'IfStatement' && node.alternate) {
-               elseToken = sourceCode.getTokenBefore(node.alternate);
-
-               checkNodeIndent(elseToken, indent, excludeCommas);
+                if (node.type !== "EmptyStatement" && astUtils.isSemicolonToken(lastToken)) {
+                    offsets.setDesiredOffset(lastToken, lastParentToken, 0);
+                }
             }
-            checkNodeIndent(node, indent, excludeCommas);
-         });
-      }
+        }
 
-      /**
-      * Check last node line indent this detects, that block closed correctly
-      * @param {ASTNode} node Node to examine
-      * @param {int} lastLineIndent needed indent
-      * @returns {void}
-      */
-      function checkLastNodeLineIndent(node, lastLineIndent) {
-         var lastToken = sourceCode.getLastToken(node),
-             endIndent = getNodeIndent(lastToken, true);
+        /**
+         * Checks the indentation for nodes that are like function calls (`CallExpression` and `NewExpression`)
+         * @param {ASTNode} node A CallExpression or NewExpression node
+         * @returns {void}
+         */
+        function addFunctionCallIndent(node) {
+            let openingParen;
 
-         if (endIndent !== lastLineIndent && isNodeFirstInLine(node, true)) {
-            report(
-               node,
-               lastLineIndent,
-               endIndent,
-               { line: lastToken.loc.start.line, column: lastToken.loc.start.column },
-               true
-            );
-         }
-      }
+            if (node.arguments.length) {
+                openingParen = sourceCode.getFirstTokenBetween(node.callee, node.arguments[0], astUtils.isOpeningParenToken);
+            } else {
+                openingParen = sourceCode.getLastToken(node, 1);
+            }
+            const closingParen = sourceCode.getLastToken(node);
 
-      /**
-      * Check first node line indent is correct
-      * @param {ASTNode} node Node to examine
-      * @param {int} firstLineIndent needed indent
-      * @returns {void}
-      */
-      function checkFirstNodeLineIndent(node, firstLineIndent) {
-         var startIndent = getNodeIndent(node, false);
+            parameterParens.add(openingParen);
+            parameterParens.add(closingParen);
+            offsets.setDesiredOffset(openingParen, sourceCode.getTokenBefore(openingParen), 0);
 
-         if (startIndent !== firstLineIndent && isNodeFirstInLine(node)) {
-            report(
-               node,
-               firstLineIndent,
-               startIndent,
-               { line: node.loc.start.line, column: node.loc.start.column }
-            );
-         }
-      }
+            addElementListIndent(node.arguments, openingParen, closingParen, options.CallExpression.arguments);
+        }
 
-      /**
-      * Returns the VariableDeclarator based on the current node
-      * if not present then return null
-      * @param {ASTNode} node node to examine
-      * @returns {ASTNode|void} if found then node otherwise null
-      */
-      function getVariableDeclaratorNode(node) {
-         var parent = node.parent;
+        /**
+         * Checks the indentation of parenthesized values, given a list of tokens in a program
+         * @param {Token[]} tokens A list of tokens
+         * @returns {void}
+         */
+        function addParensIndent(tokens) {
+            const parenStack = [];
+            const parenPairs = [];
 
-         while (parent.type !== 'VariableDeclarator' && parent.type !== 'Program') {
-            parent = parent.parent;
-         }
+            tokens.forEach(nextToken => {
 
-         return parent.type === 'VariableDeclarator' ? parent : null;
-      }
+                // Accumulate a list of parenthesis pairs
+                if (astUtils.isOpeningParenToken(nextToken)) {
+                    parenStack.push(nextToken);
+                } else if (astUtils.isClosingParenToken(nextToken)) {
+                    parenPairs.unshift({ left: parenStack.pop(), right: nextToken });
+                }
+            });
 
-      /**
-      * Check to see if the node is part of the multi-line variable declaration.
-      * Also if its on the same line as the varNode
-      * @param {ASTNode} node node to check
-      * @param {ASTNode} varNode variable declaration node to check against
-      * @returns {boolean} True if all the above condition satisfy
-      */
-      function isNodeInVarOnTop(node, varNode) {
-         return varNode &&
-         varNode.parent.loc.start.line === node.loc.start.line &&
-         varNode.parent.declarations.length > 1;
-      }
+            parenPairs.forEach(pair => {
+                const leftParen = pair.left;
+                const rightParen = pair.right;
 
-      /**
-      * Check to see if the argument before the callee node is multi-line and
-      * there should only be 1 argument before the callee node
-      * @param {ASTNode} node node to check
-      * @returns {boolean} True if arguments are multi-line
-      */
-      function isArgBeforeCalleeNodeMultiline(node) {
-         var parent = node.parent;
+                // We only want to handle parens around expressions, so exclude parentheses that are in function parameters and function call arguments.
+                if (!parameterParens.has(leftParen) && !parameterParens.has(rightParen)) {
+                    const parenthesizedTokens = new Set(sourceCode.getTokensBetween(leftParen, rightParen));
 
-         if (parent.arguments.length >= 2 && parent.arguments[1] === node) {
-            return parent.arguments[0].loc.end.line > parent.arguments[0].loc.start.line;
-         }
+                    parenthesizedTokens.forEach(token => {
+                        if (!parenthesizedTokens.has(offsets.getFirstDependency(token))) {
+                            offsets.setDesiredOffset(token, leftParen, 1);
+                        }
+                    });
+                }
 
-         return false;
-      }
+                offsets.setDesiredOffset(rightParen, leftParen, 0);
+            });
+        }
 
-      /**
-      * Check indent for function block content
-      * @param {ASTNode} node node to examine
-      * @returns {void}
-      */
-      function checkIndentInFunctionBlock(node) {
+        /**
+         * Ignore all tokens within an unknown node whose offset do not depend
+         * on another token's offset within the unknown node
+         * @param {ASTNode} node Unknown Node
+         * @returns {void}
+         */
+        function ignoreNode(node) {
+            const unknownNodeTokens = new Set(sourceCode.getTokens(node, { includeComments: true }));
 
-         /*
-         * Search first caller in chain.
-         * Ex.:
+            unknownNodeTokens.forEach(token => {
+                if (!unknownNodeTokens.has(offsets.getFirstDependency(token))) {
+                    const firstTokenOfLine = tokenInfo.getFirstTokenOfLine(token);
+
+                    if (token === firstTokenOfLine) {
+                        offsets.ignoreToken(token);
+                    } else {
+                        offsets.setDesiredOffset(token, firstTokenOfLine, 0);
+                    }
+                }
+            });
+        }
+
+        /**
+         * Check whether the given token is on the first line of a statement.
+         * @param {Token} token The token to check.
+         * @param {ASTNode} leafNode The expression node that the token belongs directly.
+         * @returns {boolean} `true` if the token is on the first line of a statement.
+         */
+        function isOnFirstLineOfStatement(token, leafNode) {
+            let node = leafNode;
+
+            while (node.parent && !node.parent.type.endsWith("Statement") && !node.parent.type.endsWith("Declaration")) {
+                node = node.parent;
+            }
+            node = node.parent;
+
+            return !node || node.loc.start.line === token.loc.start.line;
+        }
+
+        /**
+         * Check whether there are any blank (whitespace-only) lines between
+         * two tokens on separate lines.
+         * @param {Token} firstToken The first token.
+         * @param {Token} secondToken The second token.
+         * @returns {boolean} `true` if the tokens are on separate lines and
+         *   there exists a blank line between them, `false` otherwise.
+         */
+        function hasBlankLinesBetween(firstToken, secondToken) {
+            const firstTokenLine = firstToken.loc.end.line;
+            const secondTokenLine = secondToken.loc.start.line;
+
+            if (firstTokenLine === secondTokenLine || firstTokenLine === secondTokenLine - 1) {
+                return false;
+            }
+
+            for (let line = firstTokenLine + 1; line < secondTokenLine; ++line) {
+                if (!tokenInfo.firstTokensByLineNumber.has(line)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        const ignoredNodeFirstTokens = new Set();
+
+        const baseOffsetListeners = {
+            "ArrayExpression, ArrayPattern"(node) {
+                const openingBracket = sourceCode.getFirstToken(node);
+                const closingBracket = sourceCode.getTokenAfter(lodash.findLast(node.elements) || openingBracket, astUtils.isClosingBracketToken);
+
+                addElementListIndent(node.elements, openingBracket, closingBracket, options.ArrayExpression);
+            },
+
+            "ObjectExpression, ObjectPattern"(node) {
+                const openingCurly = sourceCode.getFirstToken(node);
+                const closingCurly = sourceCode.getTokenAfter(
+                    node.properties.length ? node.properties[node.properties.length - 1] : openingCurly,
+                    astUtils.isClosingBraceToken
+                );
+
+                addElementListIndent(node.properties, openingCurly, closingCurly, options.ObjectExpression);
+            },
+
+            ArrowFunctionExpression(node) {
+                const firstToken = sourceCode.getFirstToken(node);
+
+                if (astUtils.isOpeningParenToken(firstToken)) {
+                    const openingParen = firstToken;
+                    const closingParen = sourceCode.getTokenBefore(node.body, astUtils.isClosingParenToken);
+
+                    parameterParens.add(openingParen);
+                    parameterParens.add(closingParen);
+                    addElementListIndent(node.params, openingParen, closingParen, options.FunctionExpression.parameters);
+                }
+                addBlocklessNodeIndent(node.body);
+            },
+
+            AssignmentExpression(node) {
+                const operator = sourceCode.getFirstTokenBetween(node.left, node.right, token => token.value === node.operator);
+
+                offsets.setDesiredOffsets([operator.range[0], node.range[1]], sourceCode.getLastToken(node.left), 1);
+                offsets.ignoreToken(operator);
+                offsets.ignoreToken(sourceCode.getTokenAfter(operator));
+            },
+
+            "BinaryExpression, LogicalExpression"(node) {
+                const operator = sourceCode.getFirstTokenBetween(node.left, node.right, token => token.value === node.operator);
+
+                /*
+                 * For backwards compatibility, don't check BinaryExpression indents, e.g.
+                 * var foo = bar &&
+                 *                   baz;
+                 */
+
+                const tokenAfterOperator = sourceCode.getTokenAfter(operator);
+
+                offsets.ignoreToken(operator);
+                offsets.ignoreToken(tokenAfterOperator);
+                offsets.setDesiredOffset(tokenAfterOperator, operator, 0);
+            },
+
+            "BlockStatement, ClassBody"(node) {
+
+                let blockIndentLevel;
+
+                if (node.parent && isOuterIIFE(node.parent)) {
+                    blockIndentLevel = options.outerIIFEBody;
+                } else if (node.parent && (node.parent.type === "FunctionExpression" || node.parent.type === "ArrowFunctionExpression")) {
+                    blockIndentLevel = options.FunctionExpression.body;
+                } else if (node.parent && node.parent.type === "FunctionDeclaration") {
+                    blockIndentLevel = options.FunctionDeclaration.body;
+                } else {
+                    blockIndentLevel = 1;
+                }
+
+                /*
+                 * For blocks that aren't lone statements, ensure that the opening curly brace
+                 * is aligned with the parent.
+                 */
+                if (!astUtils.STATEMENT_LIST_PARENTS.has(node.parent.type)) {
+                    offsets.setDesiredOffset(sourceCode.getFirstToken(node), sourceCode.getFirstToken(node.parent), 0);
+                }
+                addElementListIndent(node.body, sourceCode.getFirstToken(node), sourceCode.getLastToken(node), blockIndentLevel);
+            },
+
+            CallExpression: addFunctionCallIndent,
+
+
+            "ClassDeclaration[superClass], ClassExpression[superClass]"(node) {
+                const classToken = sourceCode.getFirstToken(node);
+                const extendsToken = sourceCode.getTokenBefore(node.superClass, astUtils.isNotOpeningParenToken);
+
+                offsets.setDesiredOffsets([extendsToken.range[0], node.body.range[0]], classToken, 1);
+            },
+
+            ConditionalExpression(node) {
+                const firstToken = sourceCode.getFirstToken(node);
+
+                // `flatTernaryExpressions` option is for the following style:
+                // var a =
+                //     foo > 0 ? bar :
+                //     foo < 0 ? baz :
+                //     /*else*/ qiz ;
+                if (!options.flatTernaryExpressions ||
+                    !astUtils.isTokenOnSameLine(node.test, node.consequent) ||
+                    isOnFirstLineOfStatement(firstToken, node)
+                ) {
+                    const questionMarkToken = sourceCode.getFirstTokenBetween(node.test, node.consequent, token => token.type === "Punctuator" && token.value === "?");
+                    const colonToken = sourceCode.getFirstTokenBetween(node.consequent, node.alternate, token => token.type === "Punctuator" && token.value === ":");
+
+                    const firstConsequentToken = sourceCode.getTokenAfter(questionMarkToken);
+                    const lastConsequentToken = sourceCode.getTokenBefore(colonToken);
+                    const firstAlternateToken = sourceCode.getTokenAfter(colonToken);
+
+                    offsets.setDesiredOffset(questionMarkToken, firstToken, 1);
+                    offsets.setDesiredOffset(colonToken, firstToken, 1);
+
+                    offsets.setDesiredOffset(firstConsequentToken, firstToken, 1);
+
+                    /*
+                     * The alternate and the consequent should usually have the same indentation.
+                     * If they share part of a line, align the alternate against the first token of the consequent.
+                     * This allows the alternate to be indented correctly in cases like this:
+                     * foo ? (
+                     *   bar
+                     * ) : ( // this '(' is aligned with the '(' above, so it's considered to be aligned with `foo`
+                     *   baz // as a result, `baz` is offset by 1 rather than 2
+                     * )
+                     */
+                    if (lastConsequentToken.loc.end.line === firstAlternateToken.loc.start.line) {
+                        offsets.setDesiredOffset(firstAlternateToken, firstConsequentToken, 0);
+                    } else {
+
+                        /**
+                         * If the alternate and consequent do not share part of a line, offset the alternate from the first
+                         * token of the conditional expression. For example:
+                         * foo ? bar
+                         *   : baz
+                         *
+                         * If `baz` were aligned with `bar` rather than being offset by 1 from `foo`, `baz` would end up
+                         * having no expected indentation.
+                         */
+                        offsets.setDesiredOffset(firstAlternateToken, firstToken, 1);
+                    }
+                }
+            },
+
+            "DoWhileStatement, WhileStatement, ForInStatement, ForOfStatement": node => addBlocklessNodeIndent(node.body),
+
+            ExportNamedDeclaration(node) {
+                if (node.declaration === null) {
+                    const closingCurly = sourceCode.getLastToken(node, astUtils.isClosingBraceToken);
+
+                    // Indent the specifiers in `export {foo, bar, baz}`
+                    addElementListIndent(node.specifiers, sourceCode.getFirstToken(node, { skip: 1 }), closingCurly, 1);
+
+                    if (node.source) {
+
+                        // Indent everything after and including the `from` token in `export {foo, bar, baz} from 'qux'`
+                        offsets.setDesiredOffsets([closingCurly.range[1], node.range[1]], sourceCode.getFirstToken(node), 1);
+                    }
+                }
+            },
+
+            ForStatement(node) {
+                const forOpeningParen = sourceCode.getFirstToken(node, 1);
+
+                if (node.init) {
+                    offsets.setDesiredOffsets(node.init.range, forOpeningParen, 1);
+                }
+                if (node.test) {
+                    offsets.setDesiredOffsets(node.test.range, forOpeningParen, 1);
+                }
+                if (node.update) {
+                    offsets.setDesiredOffsets(node.update.range, forOpeningParen, 1);
+                }
+                addBlocklessNodeIndent(node.body);
+            },
+
+            "FunctionDeclaration, FunctionExpression"(node) {
+                const closingParen = sourceCode.getTokenBefore(node.body);
+                const openingParen = sourceCode.getTokenBefore(node.params.length ? node.params[0] : closingParen);
+
+                parameterParens.add(openingParen);
+                parameterParens.add(closingParen);
+                addElementListIndent(node.params, openingParen, closingParen, options[node.type].parameters);
+            },
+
+            IfStatement(node) {
+                addBlocklessNodeIndent(node.consequent);
+                if (node.alternate && node.alternate.type !== "IfStatement") {
+                    addBlocklessNodeIndent(node.alternate);
+                }
+            },
+
+            ImportDeclaration(node) {
+                if (node.specifiers.some(specifier => specifier.type === "ImportSpecifier")) {
+                    const openingCurly = sourceCode.getFirstToken(node, astUtils.isOpeningBraceToken);
+                    const closingCurly = sourceCode.getLastToken(node, astUtils.isClosingBraceToken);
+
+                    addElementListIndent(node.specifiers.filter(specifier => specifier.type === "ImportSpecifier"), openingCurly, closingCurly, options.ImportDeclaration);
+                }
+
+                const fromToken = sourceCode.getLastToken(node, token => token.type === "Identifier" && token.value === "from");
+                const sourceToken = sourceCode.getLastToken(node, token => token.type === "String");
+                const semiToken = sourceCode.getLastToken(node, token => token.type === "Punctuator" && token.value === ";");
+
+                if (fromToken) {
+                    const end = semiToken && semiToken.range[1] === sourceToken.range[1] ? node.range[1] : sourceToken.range[1];
+
+                    offsets.setDesiredOffsets([fromToken.range[0], end], sourceCode.getFirstToken(node), 1);
+                }
+            },
+
+            "MemberExpression, JSXMemberExpression, MetaProperty"(node) {
+                const object = node.type === "MetaProperty" ? node.meta : node.object;
+                const firstNonObjectToken = sourceCode.getFirstTokenBetween(object, node.property, astUtils.isNotClosingParenToken);
+                const secondNonObjectToken = sourceCode.getTokenAfter(firstNonObjectToken);
+
+                const objectParenCount = sourceCode.getTokensBetween(object, node.property, { filter: astUtils.isClosingParenToken }).length;
+                const firstObjectToken = objectParenCount
+                    ? sourceCode.getTokenBefore(object, { skip: objectParenCount - 1 })
+                    : sourceCode.getFirstToken(object);
+                const lastObjectToken = sourceCode.getTokenBefore(firstNonObjectToken);
+                const firstPropertyToken = node.computed ? firstNonObjectToken : secondNonObjectToken;
+
+                if (node.computed) {
+
+                    // For computed MemberExpressions, match the closing bracket with the opening bracket.
+                    offsets.setDesiredOffset(sourceCode.getLastToken(node), firstNonObjectToken, 0);
+                    offsets.setDesiredOffsets(node.property.range, firstNonObjectToken, 1);
+                }
+
+                /*
+                 * If the object ends on the same line that the property starts, match against the last token
+                 * of the object, to ensure that the MemberExpression is not indented.
+                 *
+                 * Otherwise, match against the first token of the object, e.g.
+                 * foo
+                 *   .bar
+                 *   .baz // <-- offset by 1 from `foo`
+                 */
+                const offsetBase = lastObjectToken.loc.end.line === firstPropertyToken.loc.start.line
+                    ? lastObjectToken
+                    : firstObjectToken;
+
+                if (typeof options.MemberExpression === "number") {
+
+                    // Match the dot (for non-computed properties) or the opening bracket (for computed properties) against the object.
+                    offsets.setDesiredOffset(firstNonObjectToken, offsetBase, options.MemberExpression);
+
+                    /*
+                     * For computed MemberExpressions, match the first token of the property against the opening bracket.
+                     * Otherwise, match the first token of the property against the object.
+                     */
+                    offsets.setDesiredOffset(secondNonObjectToken, node.computed ? firstNonObjectToken : offsetBase, options.MemberExpression);
+                } else {
+
+                    // If the MemberExpression option is off, ignore the dot and the first token of the property.
+                    offsets.ignoreToken(firstNonObjectToken);
+                    offsets.ignoreToken(secondNonObjectToken);
+
+                    // To ignore the property indentation, ensure that the property tokens depend on the ignored tokens.
+                    offsets.setDesiredOffset(firstNonObjectToken, offsetBase, 0);
+                    offsets.setDesiredOffset(secondNonObjectToken, firstNonObjectToken, 0);
+                }
+            },
+
+            NewExpression(node) {
+
+                // Only indent the arguments if the NewExpression has parens (e.g. `new Foo(bar)` or `new Foo()`, but not `new Foo`
+                if (node.arguments.length > 0 ||
+                        astUtils.isClosingParenToken(sourceCode.getLastToken(node)) &&
+                        astUtils.isOpeningParenToken(sourceCode.getLastToken(node, 1))) {
+                    addFunctionCallIndent(node);
+                }
+            },
+
+            Property(node) {
+                if (!node.shorthand && !node.method && node.kind === "init") {
+                    const colon = sourceCode.getFirstTokenBetween(node.key, node.value, astUtils.isColonToken);
+
+                    offsets.ignoreToken(sourceCode.getTokenAfter(colon));
+                }
+            },
+
+            SwitchStatement(node) {
+                const openingCurly = sourceCode.getTokenAfter(node.discriminant, astUtils.isOpeningBraceToken);
+                const closingCurly = sourceCode.getLastToken(node);
+
+                offsets.setDesiredOffsets([openingCurly.range[1], closingCurly.range[0]], openingCurly, options.SwitchCase);
+
+                if (node.cases.length) {
+                    sourceCode.getTokensBetween(
+                        node.cases[node.cases.length - 1],
+                        closingCurly,
+                        { includeComments: true, filter: astUtils.isCommentToken }
+                    ).forEach(token => offsets.ignoreToken(token));
+                }
+            },
+
+            SwitchCase(node) {
+                if (!(node.consequent.length === 1 && node.consequent[0].type === "BlockStatement")) {
+                    const caseKeyword = sourceCode.getFirstToken(node);
+                    const tokenAfterCurrentCase = sourceCode.getTokenAfter(node);
+
+                    offsets.setDesiredOffsets([caseKeyword.range[1], tokenAfterCurrentCase.range[0]], caseKeyword, 1);
+                }
+            },
+
+            TemplateLiteral(node) {
+                node.expressions.forEach((expression, index) => {
+                    const previousQuasi = node.quasis[index];
+                    const nextQuasi = node.quasis[index + 1];
+                    const tokenToAlignFrom = previousQuasi.loc.start.line === previousQuasi.loc.end.line
+                        ? sourceCode.getFirstToken(previousQuasi)
+                        : null;
+
+                    offsets.setDesiredOffsets([previousQuasi.range[1], nextQuasi.range[0]], tokenToAlignFrom, 1);
+                    offsets.setDesiredOffset(sourceCode.getFirstToken(nextQuasi), tokenToAlignFrom, 0);
+                });
+            },
+
+            VariableDeclaration(node) {
+                const variableIndent = Object.prototype.hasOwnProperty.call(options.VariableDeclarator, node.kind)
+                    ? options.VariableDeclarator[node.kind]
+                    : DEFAULT_VARIABLE_INDENT;
+
+                if (node.declarations[node.declarations.length - 1].loc.start.line > node.loc.start.line) {
+
+                    /*
+                     * VariableDeclarator indentation is a bit different from other forms of indentation, in that the
+                     * indentation of an opening bracket sometimes won't match that of a closing bracket. For example,
+                     * the following indentations are correct:
+                     *
+                     * var foo = {
+                     *   ok: true
+                     * };
+                     *
+                     * var foo = {
+                     *     ok: true,
+                     *   },
+                     *   bar = 1;
+                     *
+                     * Account for when exiting the AST (after indentations have already been set for the nodes in
+                     * the declaration) by manually increasing the indentation level of the tokens in this declarator
+                     * on the same line as the start of the declaration, provided that there are declarators that
+                     * follow this one.
+                     */
+                    const firstToken = sourceCode.getFirstToken(node);
+
+                    offsets.setDesiredOffsets(node.range, firstToken, variableIndent, true);
+                } else {
+                    offsets.setDesiredOffsets(node.range, sourceCode.getFirstToken(node), variableIndent);
+                }
+                const lastToken = sourceCode.getLastToken(node);
+
+                if (astUtils.isSemicolonToken(lastToken)) {
+                    offsets.ignoreToken(lastToken);
+                }
+            },
+
+            VariableDeclarator(node) {
+                if (node.init) {
+                    const equalOperator = sourceCode.getTokenBefore(node.init, astUtils.isNotOpeningParenToken);
+                    const tokenAfterOperator = sourceCode.getTokenAfter(equalOperator);
+
+                    offsets.ignoreToken(equalOperator);
+                    offsets.ignoreToken(tokenAfterOperator);
+                    offsets.setDesiredOffsets([tokenAfterOperator.range[0], node.range[1]], equalOperator, 1);
+                    offsets.setDesiredOffset(equalOperator, sourceCode.getLastToken(node.id), 0);
+                }
+            },
+
+            "JSXAttribute[value]"(node) {
+                const equalsToken = sourceCode.getFirstTokenBetween(node.name, node.value, token => token.type === "Punctuator" && token.value === "=");
+
+                offsets.setDesiredOffsets([equalsToken.range[0], node.value.range[1]], sourceCode.getFirstToken(node.name), 1);
+            },
+
+            JSXElement(node) {
+                if (node.closingElement) {
+                    addElementListIndent(node.children, sourceCode.getFirstToken(node.openingElement), sourceCode.getFirstToken(node.closingElement), 1);
+                }
+            },
+
+            JSXOpeningElement(node) {
+                const firstToken = sourceCode.getFirstToken(node);
+                let closingToken;
+
+                if (node.selfClosing) {
+                    closingToken = sourceCode.getLastToken(node, { skip: 1 });
+                    offsets.setDesiredOffset(sourceCode.getLastToken(node), closingToken, 0);
+                } else {
+                    closingToken = sourceCode.getLastToken(node);
+                }
+                offsets.setDesiredOffsets(node.name.range, sourceCode.getFirstToken(node));
+                addElementListIndent(node.attributes, firstToken, closingToken, 1);
+            },
+
+            JSXClosingElement(node) {
+                const firstToken = sourceCode.getFirstToken(node);
+
+                offsets.setDesiredOffsets(node.name.range, firstToken, 1);
+            },
+
+            JSXExpressionContainer(node) {
+                const openingCurly = sourceCode.getFirstToken(node);
+                const closingCurly = sourceCode.getLastToken(node);
+
+                offsets.setDesiredOffsets(
+                    [openingCurly.range[1], closingCurly.range[0]],
+                    openingCurly,
+                    1
+                );
+            },
+
+            "*"(node) {
+                const firstToken = sourceCode.getFirstToken(node);
+
+                // Ensure that the children of every node are indented at least as much as the first token.
+                if (firstToken && !ignoredNodeFirstTokens.has(firstToken)) {
+                    offsets.setDesiredOffsets(node.range, firstToken, 0);
+                }
+            }
+        };
+
+        const listenerCallQueue = [];
+
+        /*
+         * To ignore the indentation of a node:
+         * 1. Don't call the node's listener when entering it (if it has a listener)
+         * 2. Don't set any offsets against the first token of the node.
+         * 3. Call `ignoreNode` on the node sometime after exiting it and before validating offsets.
+         */
+        const offsetListeners = lodash.mapValues(
+            baseOffsetListeners,
+
+            /*
+             * Offset listener calls are deferred until traversal is finished, and are called as
+             * part of the final `Program:exit` listener. This is necessary because a node might
+             * be matched by multiple selectors.
+             *
+             * Example: Suppose there is an offset listener for `Identifier`, and the user has
+             * specified in configuration that `MemberExpression > Identifier` should be ignored.
+             * Due to selector specificity rules, the `Identifier` listener will get called first. However,
+             * if a given Identifier node is supposed to be ignored, then the `Identifier` offset listener
+             * should not have been called at all. Without doing extra selector matching, we don't know
+             * whether the Identifier matches the `MemberExpression > Identifier` selector until the
+             * `MemberExpression > Identifier` listener is called.
+             *
+             * To avoid this, the `Identifier` listener isn't called until traversal finishes and all
+             * ignored nodes are known.
+             */
+            listener =>
+                node =>
+                    listenerCallQueue.push({ listener, node })
+        );
+
+        // For each ignored node selector, set up a listener to collect it into the `ignoredNodes` set.
+        const ignoredNodes = new Set();
+
+        /**
+         * Ignores a node
+         * @param {ASTNode} node The node to ignore
+         * @returns {void}
+         */
+        function addToIgnoredNodes(node) {
+            ignoredNodes.add(node);
+            ignoredNodeFirstTokens.add(sourceCode.getFirstToken(node));
+        }
+
+        const ignoredNodeListeners = options.ignoredNodes.reduce(
+            (listeners, ignoredSelector) => Object.assign(listeners, { [ignoredSelector]: addToIgnoredNodes }),
+            {}
+        );
+
+        /*
+         * Join the listeners, and add a listener to verify that all tokens actually have the correct indentation
+         * at the end.
          *
-         * Models <- Identifier
-         *   .User
-         *   .find()
-         *   .exec(function() {
-         *   // function body
-         * });
-         *
-         * Looks for 'Models'
+         * Using Object.assign will cause some offset listeners to be overwritten if the same selector also appears
+         * in `ignoredNodeListeners`. This isn't a problem because all of the matching nodes will be ignored,
+         * so those listeners wouldn't be called anyway.
          */
-         var calleeNode = node.parent, // FunctionExpression
-             indent, calleeParent, parentVarNode, sameline;
+        return Object.assign(
+            offsetListeners,
+            ignoredNodeListeners,
+            {
+                "*:exit"(node) {
 
-         if (calleeNode.parent && (calleeNode.parent.type === 'Property' || calleeNode.parent.type === 'ArrayExpression')) {
-            // If function is part of array or object, comma can be put at left
-            indent = getNodeIndent(calleeNode, false, false);
-         } else {
+                    // If a node's type is nonstandard, we can't tell how its children should be offset, so ignore it.
+                    if (!KNOWN_NODES.has(node.type)) {
+                        addToIgnoredNodes(node);
+                    }
+                },
+                "Program:exit"() {
 
-            // If function is standalone, simple calculate indent
-            indent = getNodeIndent(calleeNode);
-         }
+                    // If ignoreComments option is enabled, ignore all comment tokens.
+                    if (options.ignoreComments) {
+                        sourceCode.getAllComments()
+                            .forEach(comment => offsets.ignoreToken(comment));
+                    }
 
-         if (calleeNode.parent.type === 'CallExpression') {
-            calleeParent = calleeNode.parent;
+                    // Invoke the queued offset listeners for the nodes that aren't ignored.
+                    listenerCallQueue
+                        .filter(nodeInfo => !ignoredNodes.has(nodeInfo.node))
+                        .forEach(nodeInfo => nodeInfo.listener(nodeInfo.node));
 
-            sameline = calleeParent.callee.loc.start.line === calleeParent.callee.loc.end.line;
+                    // Update the offsets for ignored nodes to prevent their child tokens from being reported.
+                    ignoredNodes.forEach(ignoreNode);
 
-            if (calleeNode.type !== 'FunctionExpression' && calleeNode.type !== 'ArrowFunctionExpression') {
-               if (calleeParent && calleeParent.loc.start.line < node.loc.start.line) {
-                  indent = getNodeIndent(calleeParent);
-               }
-            } else if (isArgBeforeCalleeNodeMultiline(calleeNode) && sameline && !isNodeFirstInLine(calleeNode)) {
-               indent = getNodeIndent(calleeParent);
+                    addParensIndent(sourceCode.ast.tokens);
+
+                    /*
+                     * Create a Map from (tokenOrComment) => (precedingToken).
+                     * This is necessary because sourceCode.getTokenBefore does not handle a comment as an argument correctly.
+                     */
+                    const precedingTokens = sourceCode.ast.comments.reduce((commentMap, comment) => {
+                        const tokenOrCommentBefore = sourceCode.getTokenBefore(comment, { includeComments: true });
+
+                        return commentMap.set(comment, commentMap.has(tokenOrCommentBefore) ? commentMap.get(tokenOrCommentBefore) : tokenOrCommentBefore);
+                    }, new WeakMap());
+
+                    sourceCode.lines.forEach((line, lineIndex) => {
+                        const lineNumber = lineIndex + 1;
+
+                        if (!tokenInfo.firstTokensByLineNumber.has(lineNumber)) {
+
+                            // Don't check indentation on blank lines
+                            return;
+                        }
+
+                        const firstTokenOfLine = tokenInfo.firstTokensByLineNumber.get(lineNumber);
+
+                        if (firstTokenOfLine.loc.start.line !== lineNumber) {
+
+                            // Don't check the indentation of multi-line tokens (e.g. template literals or block comments) twice.
+                            return;
+                        }
+
+                        // If the token matches the expected expected indentation, don't report it.
+                        if (validateTokenIndent(firstTokenOfLine, offsets.getDesiredIndent(firstTokenOfLine))) {
+                            return;
+                        }
+
+                        if (astUtils.isCommentToken(firstTokenOfLine)) {
+                            const tokenBefore = precedingTokens.get(firstTokenOfLine);
+                            const tokenAfter = tokenBefore ? sourceCode.getTokenAfter(tokenBefore) : sourceCode.ast.tokens[0];
+
+                            const mayAlignWithBefore = tokenBefore && !hasBlankLinesBetween(tokenBefore, firstTokenOfLine);
+                            const mayAlignWithAfter = tokenAfter && !hasBlankLinesBetween(firstTokenOfLine, tokenAfter);
+
+                            // If a comment matches the expected indentation of the token immediately before or after, don't report it.
+                            if (
+                                mayAlignWithBefore && validateTokenIndent(firstTokenOfLine, offsets.getDesiredIndent(tokenBefore)) ||
+                                mayAlignWithAfter && validateTokenIndent(firstTokenOfLine, offsets.getDesiredIndent(tokenAfter))
+                            ) {
+                                return;
+                            }
+                        }
+
+                        // Otherwise, report the token/comment.
+                        report(firstTokenOfLine, offsets.getDesiredIndent(firstTokenOfLine));
+                    });
+                }
             }
-         }
-
-         // function body indent should be indent + indent size
-         indent += indentSize;
-
-         // check if the node is inside a variable
-         parentVarNode = getVariableDeclaratorNode(node);
-
-         if (parentVarNode && isNodeInVarOnTop(node, parentVarNode)) {
-            // eslint-disable-next-line max-len
-            indent += indentSize * options.VariableDeclarator[parentVarNode.parent.kind] + options.VariableDeclaratorOffset[parentVarNode.parent.kind];
-         }
-
-         if (node.body.length > 0) {
-            checkNodesIndent(node.body, indent);
-         }
-
-         checkLastNodeLineIndent(node, indent - indentSize);
-      }
-
-
-      /**
-      * Checks if the given node starts and ends on the same line
-      * @param {ASTNode} node The node to check
-      * @returns {boolean} Whether or not the block starts and ends on the same line.
-      */
-      function isSingleLineNode(node) {
-         var lastToken = sourceCode.getLastToken(node),
-             startLine = node.loc.start.line,
-             endLine = lastToken.loc.end.line;
-
-         return startLine === endLine;
-      }
-
-      /**
-      * Check to see if the first element inside an array is an object and on the same
-      * line as the node
-      * If the node is not an array then it will return false.
-      * @param {ASTNode} node node to check
-      * @returns {boolean} success/failure
-      */
-      function isFirstArrayElementOnSameLine(node) {
-         if (node.type === 'ArrayExpression' && node.elements[0]) {
-            return node.elements[0].loc.start.line === node.loc.start.line && node.elements[0].type === 'ObjectExpression';
-         }
-
-         return false;
-      }
-
-      /**
-      * Check indent for array block content or object block content
-      * @param {ASTNode} node node to examine
-      * @returns {void}
-      */
-      // eslint-disable-next-line complexity
-      function checkIndentInArrayOrObjectBlock(node) {
-         var parentVarNode = getVariableDeclaratorNode(node),
-             nodeIndent, elementsIndent, elements, parent, effectiveParent,
-             parentTypeCheck, effectiveParentTypeCheck;
-
-         // Skip inline
-         if (isSingleLineNode(node)) {
-            return;
-         }
-
-         elements = (node.type === 'ArrayExpression') ? node.elements : node.properties;
-
-         // filter out empty elements example would be [ , 2] so remove first element as
-         // espree considers it as null
-         elements = elements.filter(function(elem) {
-            return elem !== null;
-         });
-
-         // Skip if first element is in same line with this node
-         if (elements.length > 0 && elements[0].loc.start.line === node.loc.start.line) {
-            return;
-         }
-
-
-         // TODO - come up with a better strategy in future
-         if (isNodeFirstInLine(node)) {
-            parent = node.parent;
-            effectiveParent = parent;
-
-            if (parent.type === 'MemberExpression') {
-               if (isNodeFirstInLine(parent)) {
-                  effectiveParent = parent.parent.parent;
-               } else {
-                  effectiveParent = parent.parent;
-               }
-            }
-            nodeIndent = getNodeIndent(effectiveParent);
-
-            effectiveParentTypeCheck = [ 'MemberExpression', 'ExpressionStatement', 'AssignmentExpression', 'Property' ];
-
-            if (parentVarNode && parentVarNode.loc.start.line !== node.loc.start.line) {
-               if (parent.type !== 'VariableDeclarator' || parentVarNode === parentVarNode.parent.declarations[0]) {
-
-                  parentTypeCheck = [ 'ObjectExpression', 'ArrayExpression', 'CallExpression', 'ArrowFunctionExpression', 'NewExpression' ];
-
-                  if (parent.type === 'VariableDeclarator' && parentVarNode.loc.start.line === effectiveParent.loc.start.line) {
-                     // eslint-disable-next-line max-len
-                     nodeIndent = nodeIndent + (indentSize * options.VariableDeclarator[parentVarNode.parent.kind]) + options.VariableDeclaratorOffset[parentVarNode.parent.kind];
-                  } else if (_.contains(parentTypeCheck, parent.Type)) {
-                     nodeIndent = nodeIndent + indentSize;
-                  }
-               }
-            } else if (!parentVarNode && !isFirstArrayElementOnSameLine(parent) && !_.contains(effectiveParentTypeCheck, parent.type)) {
-               nodeIndent = nodeIndent + indentSize;
-            }
-
-            elementsIndent = nodeIndent + indentSize;
-
-            checkFirstNodeLineIndent(node, nodeIndent);
-         } else {
-            nodeIndent = getNodeIndent(node);
-            elementsIndent = nodeIndent + indentSize;
-         }
-
-         /*
-         * Check if the node is a multiple variable declaration; if so, then
-         * make sure indentation takes that into account.
-         */
-         if (isNodeInVarOnTop(node, parentVarNode)) {
-            // eslint-disable-next-line max-len
-            elementsIndent += indentSize * options.VariableDeclarator[parentVarNode.parent.kind] + options.VariableDeclaratorOffset[parentVarNode.parent.kind];
-         }
-
-         // Comma can be placed before property name
-         checkNodesIndent(elements, elementsIndent, true);
-
-         if (elements.length > 0) {
-
-            // Skip last block line check if last item in same line
-            if (elements[elements.length - 1].loc.end.line === node.loc.end.line) {
-               return;
-            }
-         }
-
-         checkLastNodeLineIndent(node, elementsIndent - indentSize);
-      }
-
-      /**
-      * Check if the node or node body is a BlockStatement or not
-      * @param {ASTNode} node node to test
-      * @returns {boolean} True if it or its body is a block statement
-      */
-      function isNodeBodyBlock(node) {
-         return node.type === 'BlockStatement' || node.type === 'ClassBody' || (node.body && node.body.type === 'BlockStatement') ||
-         (node.consequent && node.consequent.type === 'BlockStatement');
-      }
-
-      /**
-      * Check indentation for blocks
-      * @param {ASTNode} node node to check
-      * @returns {void}
-      */
-      function blockIndentationCheck(node) {
-         var nodesToCheck = [],
-             indent, statementsWithProperties, parentTypeCheck;
-
-         // Skip inline blocks
-         if (isSingleLineNode(node)) {
-            return;
-         }
-
-         parentTypeCheck = [ 'FunctionExpression', 'FunctionDeclaration', 'ArrowFunctionExpression' ];
-
-         if (node.parent && _.contains(parentTypeCheck, node.parent.type)) {
-            checkIndentInFunctionBlock(node);
-            return;
-         }
-
-
-         /*
-         * For this statements we should check indent from statement beginning,
-         * not from the beginning of the block.
-         */
-         statementsWithProperties = [
-            'IfStatement', 'WhileStatement', 'ForStatement', 'ForInStatement', 'ForOfStatement', 'DoWhileStatement', 'ClassDeclaration',
-         ];
-
-         if (node.parent && statementsWithProperties.indexOf(node.parent.type) !== -1 && isNodeBodyBlock(node)) {
-            indent = getNodeIndent(node.parent);
-         } else {
-            indent = getNodeIndent(node);
-         }
-
-         if (node.type === 'IfStatement' && node.consequent.type !== 'BlockStatement') {
-            nodesToCheck = [ node.consequent ];
-         } else if (util.isArray(node.body)) {
-            nodesToCheck = node.body;
-         } else {
-            nodesToCheck = [ node.body ];
-         }
-
-         if (nodesToCheck.length > 0) {
-            checkNodesIndent(nodesToCheck, indent + indentSize);
-         }
-
-         if (node.type === 'BlockStatement') {
-            checkLastNodeLineIndent(node, indent);
-         }
-      }
-
-      /**
-      * Filter out the elements which are on the same line of each other or the node.
-      * basically have only 1 elements from each line except the variable declaration
-      * line.
-      * @param {ASTNode} node Variable declaration node
-      * @returns {ASTNode[]} Filtered elements
-      */
-      function filterOutSameLineVars(node) {
-         return node.declarations.reduce(function(finalCollection, elem) {
-            var lastElem = finalCollection[finalCollection.length - 1],
-                elemLineCheck, lastElemLineCheck;
-
-            elemLineCheck = (elem.loc.start.line !== node.loc.start.line && !lastElem);
-            lastElemLineCheck = (lastElem && lastElem.loc.start.line !== elem.loc.start.line);
-
-            if (elemLineCheck || lastElemLineCheck) {
-               finalCollection.push(elem);
-            }
-
-            return finalCollection;
-         }, []);
-      }
-
-      /**
-      * Check indentation for variable declarations
-      * @param {ASTNode} node node to examine
-      * @returns {void}
-      */
-      function checkIndentInVariableDeclarations(node) {
-         var elements = filterOutSameLineVars(node),
-             nodeIndent = getNodeIndent(node),
-             lastElement = elements[elements.length - 1],
-             elementsIndent = nodeIndent + indentSize * options.VariableDeclarator[node.kind] + options.VariableDeclaratorOffset[node.kind],
-             tokenBeforeLastElement;
-
-         // Comma can be placed before declaration
-         checkNodesIndent(elements, elementsIndent, true);
-
-         // Only check the last line if there is any token after the last item
-         if (sourceCode.getLastToken(node).loc.end.line <= lastElement.loc.end.line) {
-            return;
-         }
-
-         tokenBeforeLastElement = sourceCode.getTokenBefore(lastElement);
-
-         if (tokenBeforeLastElement.value === ',') {
-            // Special case for comma-first syntax where the semicolon is indented
-            checkLastNodeLineIndent(node, getNodeIndent(tokenBeforeLastElement));
-         } else {
-            checkLastNodeLineIndent(node, elementsIndent - indentSize);
-         }
-      }
-
-      /**
-      * Check and decide whether to check for indentation for blockless nodes
-      * Scenarios are for or while statements without braces around them
-      * @param {ASTNode} node node to examine
-      * @returns {void}
-      */
-      function blockLessNodes(node) {
-         if (node.body.type !== 'BlockStatement') {
-            blockIndentationCheck(node);
-         }
-      }
-
-      /**
-      * Returns the expected indentation for the case statement
-      * @param {ASTNode} node node to examine
-      * @param {int} [switchIndent] indent for switch statement
-      * @returns {int} indent size
-      */
-      function expectedCaseIndent(node, switchIndent) {
-         var switchNode = (node.type === 'SwitchStatement') ? node : node.parent,
-             caseIndent;
-
-         if (caseIndentStore[switchNode.loc.start.line]) {
-            return caseIndentStore[switchNode.loc.start.line];
-         }
-
-         if (typeof switchIndent === 'undefined') {
-            switchIndent = getNodeIndent(switchNode);
-         }
-
-         if (switchNode.cases.length > 0 && options.SwitchCase === 0) {
-            caseIndent = switchIndent;
-         } else {
-            caseIndent = switchIndent + (indentSize * options.SwitchCase);
-         }
-
-         caseIndentStore[switchNode.loc.start.line] = caseIndent;
-         return caseIndent;
-      }
-
-      return {
-         Program: function(node) {
-            if (node.body.length > 0) {
-
-               // Root nodes should have no indent
-               checkNodesIndent(node.body, getNodeIndent(node));
-            }
-         },
-
-         ClassBody: blockIndentationCheck,
-
-         BlockStatement: blockIndentationCheck,
-
-         WhileStatement: blockLessNodes,
-
-         ForStatement: blockLessNodes,
-
-         ForInStatement: blockLessNodes,
-
-         ForOfStatement: blockLessNodes,
-
-         DoWhileStatement: blockLessNodes,
-
-         IfStatement: function(node) {
-            if (node.consequent.type !== 'BlockStatement' && node.consequent.loc.start.line > node.loc.start.line) {
-               blockIndentationCheck(node);
-            }
-         },
-
-         VariableDeclaration: function(node) {
-            if (node.declarations[node.declarations.length - 1].loc.start.line > node.declarations[0].loc.start.line) {
-               checkIndentInVariableDeclarations(node);
-            }
-         },
-
-         ObjectExpression: function(node) {
-            checkIndentInArrayOrObjectBlock(node);
-         },
-
-         ArrayExpression: function(node) {
-            checkIndentInArrayOrObjectBlock(node);
-         },
-
-         SwitchStatement: function(node) {
-
-            // Switch is not a 'BlockStatement'
-            var switchIndent = getNodeIndent(node),
-                caseIndent = expectedCaseIndent(node, switchIndent);
-
-            checkNodesIndent(node.cases, caseIndent);
-
-
-            checkLastNodeLineIndent(node, switchIndent);
-         },
-
-         SwitchCase: function(node) {
-            var caseIndent;
-
-            // Skip inline cases
-            if (isSingleLineNode(node)) {
-               return;
-            }
-            caseIndent = expectedCaseIndent(node);
-
-            checkNodesIndent(node.consequent, caseIndent + indentSize);
-         },
-      };
-
-   },
+        );
+    }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,22 +4,79 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@silvermine/eslint-config": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@silvermine/eslint-config/-/eslint-config-1.5.0.tgz",
-      "integrity": "sha512-SYETGiTIwJauHojTaqpY9PrmaaNILtCqWicL0XUo8HFPuWbY6LshVyVaHbF69nnI15/9wuXcAuq1tPH5ST1xew==",
+    "@babel/code-frame": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+      "dev": true,
       "requires": {
-        "@silvermine/eslint-plugin-silvermine": "1.2.1"
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "@silvermine/eslint-config": {
+      "version": "2.0.0-preview.2",
+      "resolved": "https://registry.npmjs.org/@silvermine/eslint-config/-/eslint-config-2.0.0-preview.2.tgz",
+      "integrity": "sha512-yRq67Rf3GyFEQD/r+B5l391AYZ1uyfKmAljpEqgxUKKG0aoh3E4VPeWTkoIuvxhlkw+uVCIP7zvIUPSaMKKWfA==",
+      "requires": {
+        "@silvermine/eslint-plugin-silvermine": "2.0.0-preview.1",
+        "eslint-plugin-typescript": "0.14.0",
+        "typescript": "3.0.3",
+        "typescript-eslint-parser": "17.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+        },
+        "typescript-eslint-parser": {
+          "version": "17.0.1",
+          "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-17.0.1.tgz",
+          "integrity": "sha512-EPCOjxjnGqu9kQwH3CAwa1Jjty2Dn0FnehksVEmfZxXtkEK2Jerb2lnd/htsj1XooqEkKC5AzCaK+qOxHaBDBQ==",
+          "requires": {
+            "lodash.unescape": "4.0.1",
+            "semver": "5.5.0"
+          }
+        }
       }
     },
     "@silvermine/eslint-plugin-silvermine": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@silvermine/eslint-plugin-silvermine/-/eslint-plugin-silvermine-1.2.1.tgz",
-      "integrity": "sha512-dmTKaZ49wDB3j3RvwGMdDA7BcgY0esySbVb/9MzLsvsYLcViBqAyC+Dc9OInmglSQPuFnLe47tQNHLExqgkoIQ==",
+      "version": "2.0.0-preview.1",
+      "resolved": "https://registry.npmjs.org/@silvermine/eslint-plugin-silvermine/-/eslint-plugin-silvermine-2.0.0-preview.1.tgz",
+      "integrity": "sha512-NeUbHq1TfihLGVVILSD6xa/r+cSF8Hnko0ch/M2ot3MDJszDKuJUbj9XZyNfPRfIxKpVjTutipp32pZpkbJuEw==",
       "requires": {
+        "@silvermine/eslint-config": "1.5.0",
         "class.extend": "0.9.2",
         "lodash.assign": "4.2.0",
         "underscore": "1.8.3"
+      },
+      "dependencies": {
+        "@silvermine/eslint-config": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/@silvermine/eslint-config/-/eslint-config-1.5.0.tgz",
+          "integrity": "sha512-SYETGiTIwJauHojTaqpY9PrmaaNILtCqWicL0XUo8HFPuWbY6LshVyVaHbF69nnI15/9wuXcAuq1tPH5ST1xew=="
+        },
+        "@silvermine/eslint-plugin-silvermine": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@silvermine/eslint-plugin-silvermine/-/eslint-plugin-silvermine-1.2.1.tgz",
+          "integrity": "sha512-dmTKaZ49wDB3j3RvwGMdDA7BcgY0esySbVb/9MzLsvsYLcViBqAyC+Dc9OInmglSQPuFnLe47tQNHLExqgkoIQ==",
+          "requires": {
+            "class.extend": "0.9.2",
+            "lodash.assign": "4.2.0",
+            "underscore": "1.8.3"
+          }
+        }
       }
     },
     "abbrev": {
@@ -29,27 +86,16 @@
       "dev": true
     },
     "acorn": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
+      "integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg==",
       "dev": true
     },
     "acorn-jsx": {
-      "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-      "dev": true,
-      "requires": {
-        "acorn": "3.3.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "3.3.0",
-          "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-          "dev": true
-        }
-      }
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+      "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+      "dev": true
     },
     "ajv": {
       "version": "6.5.5",
@@ -57,10 +103,10 @@
       "integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "2.0.1",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.4.1",
-        "uri-js": "4.2.2"
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "ajv-keywords": {
@@ -83,16 +129,19 @@
       "dev": true
     },
     "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
       "dev": true
     },
     "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
     },
     "argparse": {
       "version": "1.0.10",
@@ -100,7 +149,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "array-find-index": {
@@ -115,13 +164,19 @@
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": "~2.1.0"
       }
     },
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
     "async": {
@@ -154,23 +209,41 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
         "chalk": {
           "version": "1.1.3",
           "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
@@ -178,7 +251,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         }
       }
@@ -195,7 +268,7 @@
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "brace-expansion": {
@@ -204,7 +277,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -232,7 +305,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "0.2.0"
+        "callsites": "^0.2.0"
       }
     },
     "callsites": {
@@ -253,8 +326,8 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
       }
     },
     "caseless": {
@@ -269,9 +342,9 @@
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.5.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -280,7 +353,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.3"
+            "color-convert": "^1.9.0"
           }
         },
         "supports-color": {
@@ -289,15 +362,15 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
     },
     "chardet": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
     "circular-json": {
@@ -317,7 +390,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "2.0.0"
+        "restore-cursor": "^2.0.0"
       }
     },
     "cli-width": {
@@ -365,7 +438,7 @@
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "dev": true,
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -387,10 +460,10 @@
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
-        "buffer-from": "1.1.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "typedarray": "0.0.6"
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "core-util-is": {
@@ -405,23 +478,25 @@
       "integrity": "sha512-Tv0LKe/MkBOilH2v7WBiTBdudg2ChfGbdXafc/s330djpF3zKOmuehTeRwjXWc7pzfj9FrDUTA7tEx6Div8NFw==",
       "dev": true,
       "requires": {
-        "growl": "1.10.5",
-        "js-yaml": "3.12.0",
-        "lcov-parse": "0.0.10",
-        "log-driver": "1.2.7",
-        "minimist": "1.2.0",
-        "request": "2.88.0"
+        "growl": "~> 1.10.0",
+        "js-yaml": "^3.11.0",
+        "lcov-parse": "^0.0.10",
+        "log-driver": "^1.2.7",
+        "minimist": "^1.2.0",
+        "request": "^2.85.0"
       }
     },
     "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.3",
-        "shebang-command": "1.2.0",
-        "which": "1.3.1"
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "currently-unhandled": {
@@ -430,7 +505,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "1.0.2"
+        "array-find-index": "^1.0.1"
       }
     },
     "dashdash": {
@@ -439,7 +514,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "dateformat": {
@@ -448,17 +523,17 @@
       "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1",
-        "meow": "3.7.0"
+        "get-stdin": "^4.0.1",
+        "meow": "^3.3.0"
       }
     },
     "debug": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+      "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
       "dev": true,
       "requires": {
-        "ms": "2.1.1"
+        "ms": "^2.1.1"
       }
     },
     "decamelize": {
@@ -491,7 +566,7 @@
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2"
+        "esutils": "^2.0.2"
       }
     },
     "ecc-jsbn": {
@@ -500,8 +575,8 @@
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "requires": {
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "error-ex": {
@@ -510,7 +585,7 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "escape-string-regexp": {
@@ -525,11 +600,11 @@
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "dev": true,
       "requires": {
-        "esprima": "2.7.3",
-        "estraverse": "1.9.3",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.2.0"
+        "esprima": "^2.7.1",
+        "estraverse": "^1.9.1",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.2.0"
       },
       "dependencies": {
         "esprima": {
@@ -547,86 +622,73 @@
       }
     },
     "eslint": {
-      "version": "4.19.1",
-      "resolved": "http://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
-      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.10.0.tgz",
+      "integrity": "sha512-HpqzC+BHULKlnPwWae9MaVZ5AXJKpkxCVXQHrFaRw3hbDj26V/9ArYM4Rr/SQ8pi6qUPLXSSXC4RBJlyq2Z2OQ==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "babel-code-frame": "6.26.0",
-        "chalk": "2.4.1",
-        "concat-stream": "1.6.2",
-        "cross-spawn": "5.1.0",
-        "debug": "3.2.6",
-        "doctrine": "2.1.0",
-        "eslint-scope": "3.7.3",
-        "eslint-visitor-keys": "1.0.0",
-        "espree": "3.5.4",
-        "esquery": "1.0.1",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "functional-red-black-tree": "1.0.1",
-        "glob": "7.1.3",
-        "globals": "11.9.0",
-        "ignore": "3.3.10",
-        "imurmurhash": "0.1.4",
-        "inquirer": "3.3.0",
-        "is-resolvable": "1.1.0",
-        "js-yaml": "3.12.0",
-        "json-stable-stringify-without-jsonify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.11",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "7.0.0",
-        "progress": "2.0.1",
-        "regexpp": "1.1.0",
-        "require-uncached": "1.0.3",
-        "semver": "5.6.0",
-        "strip-ansi": "4.0.0",
-        "strip-json-comments": "2.0.1",
-        "table": "4.0.2",
-        "text-table": "0.2.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "5.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-          "dev": true,
-          "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.1.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
-          }
-        },
-        "fast-deep-equal": {
-          "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-          "dev": true
-        },
-        "json-schema-traverse": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-          "dev": true
-        }
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.5.3",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^4.0.0",
+        "eslint-utils": "^1.3.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^5.0.0",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.7.0",
+        "ignore": "^4.0.6",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^6.1.0",
+        "js-yaml": "^3.12.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.5",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.5.1",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "^2.0.1",
+        "table": "^5.0.2",
+        "text-table": "^0.2.0"
+      }
+    },
+    "eslint-plugin-typescript": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-typescript/-/eslint-plugin-typescript-0.14.0.tgz",
+      "integrity": "sha512-2u1WnnDF2mkWWgU1lFQ2RjypUlmRoBEvQN02y9u+IL12mjWlkKFGEBnVsjs9Y8190bfPQCvWly1c2rYYUSOxWw==",
+      "requires": {
+        "requireindex": "~1.1.0"
       }
     },
     "eslint-scope": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
-      "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
+      "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
       "dev": true,
       "requires": {
-        "esrecurse": "4.2.1",
-        "estraverse": "4.2.0"
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
+    },
+    "eslint-utils": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
+      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
+      "dev": true
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",
@@ -635,13 +697,14 @@
       "dev": true
     },
     "espree": {
-      "version": "3.5.4",
-      "resolved": "http://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.0.tgz",
+      "integrity": "sha512-1MpUfwsdS9MMoN7ZXqAr9e9UKdVHDcvrJpyx7mm1WuQlx/ygErEQBzgi5Nh5qBHIoYweprhtMkTCb9GhcAIcsA==",
       "dev": true,
       "requires": {
-        "acorn": "5.7.3",
-        "acorn-jsx": "3.0.1"
+        "acorn": "^6.0.2",
+        "acorn-jsx": "^5.0.0",
+        "eslint-visitor-keys": "^1.0.0"
       }
     },
     "esprima": {
@@ -656,7 +719,7 @@
       "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.0.0"
       }
     },
     "esrecurse": {
@@ -665,7 +728,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.1.0"
       }
     },
     "estraverse": {
@@ -699,14 +762,14 @@
       "dev": true
     },
     "external-editor": {
-      "version": "2.2.0",
-      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+      "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
       "dev": true,
       "requires": {
-        "chardet": "0.4.2",
-        "iconv-lite": "0.4.24",
-        "tmp": "0.0.33"
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
       }
     },
     "extsprintf": {
@@ -739,7 +802,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-entry-cache": {
@@ -748,8 +811,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.3.4",
-        "object-assign": "4.1.1"
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       }
     },
     "find-up": {
@@ -758,8 +821,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "findup-sync": {
@@ -768,7 +831,7 @@
       "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
       "dev": true,
       "requires": {
-        "glob": "5.0.15"
+        "glob": "~5.0.0"
       },
       "dependencies": {
         "glob": {
@@ -777,11 +840,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -792,10 +855,10 @@
       "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.3",
-        "graceful-fs": "4.1.15",
-        "rimraf": "2.6.2",
-        "write": "0.2.1"
+        "circular-json": "^0.3.1",
+        "graceful-fs": "^4.1.2",
+        "rimraf": "~2.6.2",
+        "write": "^0.2.1"
       }
     },
     "forever-agent": {
@@ -810,9 +873,9 @@
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.7",
-        "mime-types": "2.1.21"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
       }
     },
     "fs.realpath": {
@@ -845,7 +908,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "glob": {
@@ -854,12 +917,12 @@
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "globals": {
@@ -886,23 +949,23 @@
       "integrity": "sha512-/JzmZNPfKorlCrrmxWqQO4JVodO+DVd5XX4DkocL/1WlLlKVLE9+SdEIempOAxDhWPysLle6afvn/hg7Ck2k9g==",
       "dev": true,
       "requires": {
-        "coffeescript": "1.10.0",
-        "dateformat": "1.0.12",
-        "eventemitter2": "0.4.14",
-        "exit": "0.1.2",
-        "findup-sync": "0.3.0",
-        "glob": "7.0.6",
-        "grunt-cli": "1.2.0",
-        "grunt-known-options": "1.1.1",
-        "grunt-legacy-log": "2.0.0",
-        "grunt-legacy-util": "1.1.1",
-        "iconv-lite": "0.4.24",
-        "js-yaml": "3.5.5",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "path-is-absolute": "1.0.1",
-        "rimraf": "2.6.2"
+        "coffeescript": "~1.10.0",
+        "dateformat": "~1.0.12",
+        "eventemitter2": "~0.4.13",
+        "exit": "~0.1.1",
+        "findup-sync": "~0.3.0",
+        "glob": "~7.0.0",
+        "grunt-cli": "~1.2.0",
+        "grunt-known-options": "~1.1.0",
+        "grunt-legacy-log": "~2.0.0",
+        "grunt-legacy-util": "~1.1.1",
+        "iconv-lite": "~0.4.13",
+        "js-yaml": "~3.5.2",
+        "minimatch": "~3.0.2",
+        "mkdirp": "~0.5.1",
+        "nopt": "~3.0.6",
+        "path-is-absolute": "~1.0.0",
+        "rimraf": "~2.6.2"
       },
       "dependencies": {
         "esprima": {
@@ -917,12 +980,12 @@
           "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "js-yaml": {
@@ -931,8 +994,8 @@
           "integrity": "sha1-A3fDgBfKvHMisNH7zSWkkWQfL74=",
           "dev": true,
           "requires": {
-            "argparse": "1.0.10",
-            "esprima": "2.7.3"
+            "argparse": "^1.0.2",
+            "esprima": "^2.6.0"
           }
         }
       }
@@ -943,10 +1006,10 @@
       "integrity": "sha1-VisRnrsGndtGSs4oRVAb6Xs1tqg=",
       "dev": true,
       "requires": {
-        "findup-sync": "0.3.0",
-        "grunt-known-options": "1.1.1",
-        "nopt": "3.0.6",
-        "resolve": "1.1.7"
+        "findup-sync": "~0.3.0",
+        "grunt-known-options": "~1.1.0",
+        "nopt": "~3.0.6",
+        "resolve": "~1.1.0"
       }
     },
     "grunt-eslint": {
@@ -955,8 +1018,217 @@
       "integrity": "sha512-VZlDOLrB2KKefDDcx/wR8rEEz7smDwDKVblmooa+itdt/2jWw3ee2AiZB5Ap4s4AoRY0pbHRjZ3HHwY8uKR9Rw==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "eslint": "4.19.1"
+        "chalk": "^2.1.0",
+        "eslint": "^4.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.7.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+          "dev": true
+        },
+        "acorn-jsx": {
+          "version": "3.0.1",
+          "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+          "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+          "dev": true,
+          "requires": {
+            "acorn": "^3.0.4"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "3.3.0",
+              "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+              "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+              "dev": true
+            }
+          }
+        },
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "chardet": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+          "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "eslint": {
+          "version": "4.19.1",
+          "resolved": "http://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+          "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+          "dev": true,
+          "requires": {
+            "ajv": "^5.3.0",
+            "babel-code-frame": "^6.22.0",
+            "chalk": "^2.1.0",
+            "concat-stream": "^1.6.0",
+            "cross-spawn": "^5.1.0",
+            "debug": "^3.1.0",
+            "doctrine": "^2.1.0",
+            "eslint-scope": "^3.7.1",
+            "eslint-visitor-keys": "^1.0.0",
+            "espree": "^3.5.4",
+            "esquery": "^1.0.0",
+            "esutils": "^2.0.2",
+            "file-entry-cache": "^2.0.0",
+            "functional-red-black-tree": "^1.0.1",
+            "glob": "^7.1.2",
+            "globals": "^11.0.1",
+            "ignore": "^3.3.3",
+            "imurmurhash": "^0.1.4",
+            "inquirer": "^3.0.6",
+            "is-resolvable": "^1.0.0",
+            "js-yaml": "^3.9.1",
+            "json-stable-stringify-without-jsonify": "^1.0.1",
+            "levn": "^0.3.0",
+            "lodash": "^4.17.4",
+            "minimatch": "^3.0.2",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.8.2",
+            "path-is-inside": "^1.0.2",
+            "pluralize": "^7.0.0",
+            "progress": "^2.0.0",
+            "regexpp": "^1.0.1",
+            "require-uncached": "^1.0.3",
+            "semver": "^5.3.0",
+            "strip-ansi": "^4.0.0",
+            "strip-json-comments": "~2.0.1",
+            "table": "4.0.2",
+            "text-table": "~0.2.0"
+          }
+        },
+        "eslint-scope": {
+          "version": "3.7.3",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
+          "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "espree": {
+          "version": "3.5.4",
+          "resolved": "http://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+          "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+          "dev": true,
+          "requires": {
+            "acorn": "^5.5.0",
+            "acorn-jsx": "^3.0.0"
+          }
+        },
+        "external-editor": {
+          "version": "2.2.0",
+          "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+          "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+          "dev": true,
+          "requires": {
+            "chardet": "^0.4.0",
+            "iconv-lite": "^0.4.17",
+            "tmp": "^0.0.33"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+          "dev": true
+        },
+        "ignore": {
+          "version": "3.3.10",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+          "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.0.4",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rx-lite": "^4.0.8",
+            "rx-lite-aggregates": "^4.0.8",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+          "dev": true
+        },
+        "regexpp": {
+          "version": "1.1.0",
+          "resolved": "http://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+          "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+          "dev": true
+        },
+        "slice-ansi": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+          "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0"
+          }
+        },
+        "table": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+          "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+          "dev": true,
+          "requires": {
+            "ajv": "^5.2.3",
+            "ajv-keywords": "^2.1.0",
+            "chalk": "^2.1.0",
+            "lodash": "^4.17.4",
+            "slice-ansi": "1.0.0",
+            "string-width": "^2.1.1"
+          }
+        }
       }
     },
     "grunt-known-options": {
@@ -971,10 +1243,10 @@
       "integrity": "sha512-1m3+5QvDYfR1ltr8hjiaiNjddxGdQWcH0rw1iKKiQnF0+xtgTazirSTGu68RchPyh1OBng1bBUjLmX8q9NpoCw==",
       "dev": true,
       "requires": {
-        "colors": "1.1.2",
-        "grunt-legacy-log-utils": "2.0.1",
-        "hooker": "0.2.3",
-        "lodash": "4.17.11"
+        "colors": "~1.1.2",
+        "grunt-legacy-log-utils": "~2.0.0",
+        "hooker": "~0.2.3",
+        "lodash": "~4.17.5"
       }
     },
     "grunt-legacy-log-utils": {
@@ -983,8 +1255,8 @@
       "integrity": "sha512-o7uHyO/J+i2tXG8r2bZNlVk20vlIFJ9IEYyHMCQGfWYru8Jv3wTqKZzvV30YW9rWEjq0eP3cflQ1qWojIe9VFA==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "lodash": "4.17.11"
+        "chalk": "~2.4.1",
+        "lodash": "~4.17.10"
       }
     },
     "grunt-legacy-util": {
@@ -993,13 +1265,13 @@
       "integrity": "sha512-9zyA29w/fBe6BIfjGENndwoe1Uy31BIXxTH3s8mga0Z5Bz2Sp4UCjkeyv2tI449ymkx3x26B+46FV4fXEddl5A==",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "exit": "0.1.2",
-        "getobject": "0.1.0",
-        "hooker": "0.2.3",
-        "lodash": "4.17.11",
-        "underscore.string": "3.3.5",
-        "which": "1.3.1"
+        "async": "~1.5.2",
+        "exit": "~0.1.1",
+        "getobject": "~0.1.0",
+        "hooker": "~0.2.3",
+        "lodash": "~4.17.10",
+        "underscore.string": "~3.3.4",
+        "which": "~1.3.0"
       }
     },
     "handlebars": {
@@ -1008,10 +1280,10 @@
       "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
       "dev": true,
       "requires": {
-        "async": "2.6.1",
-        "optimist": "0.6.1",
-        "source-map": "0.6.1",
-        "uglify-js": "3.4.9"
+        "async": "^2.5.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4"
       },
       "dependencies": {
         "async": {
@@ -1020,7 +1292,7 @@
           "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.11"
+            "lodash": "^4.17.10"
           }
         },
         "source-map": {
@@ -1043,8 +1315,8 @@
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "dev": true,
       "requires": {
-        "ajv": "6.5.5",
-        "har-schema": "2.0.0"
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
       }
     },
     "has-ansi": {
@@ -1053,7 +1325,15 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        }
       }
     },
     "has-flag": {
@@ -1086,9 +1366,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.15.2"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "iconv-lite": {
@@ -1097,13 +1377,13 @@
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "ignore": {
-      "version": "3.3.10",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
     },
     "imurmurhash": {
@@ -1118,7 +1398,7 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "inflight": {
@@ -1127,8 +1407,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -1138,25 +1418,41 @@
       "dev": true
     },
     "inquirer": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.1.tgz",
+      "integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.1.0",
-        "chalk": "2.4.1",
-        "cli-cursor": "2.1.0",
-        "cli-width": "2.2.0",
-        "external-editor": "2.2.0",
-        "figures": "2.0.0",
-        "lodash": "4.17.11",
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.0",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.10",
         "mute-stream": "0.0.7",
-        "run-async": "2.3.0",
-        "rx-lite": "4.0.8",
-        "rx-lite-aggregates": "4.0.8",
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "through": "2.3.8"
+        "run-async": "^2.2.0",
+        "rxjs": "^6.1.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.0.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
+          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.0.0"
+          }
+        }
       }
     },
     "is-arrayish": {
@@ -1171,7 +1467,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-finite": {
@@ -1180,7 +1476,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -1237,20 +1533,20 @@
       "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.9",
-        "async": "1.5.2",
-        "escodegen": "1.8.1",
-        "esprima": "2.7.3",
-        "glob": "5.0.15",
-        "handlebars": "4.0.12",
-        "js-yaml": "3.12.0",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "once": "1.4.0",
-        "resolve": "1.1.7",
-        "supports-color": "3.2.3",
-        "which": "1.3.1",
-        "wordwrap": "1.0.0"
+        "abbrev": "1.0.x",
+        "async": "1.x",
+        "escodegen": "1.8.x",
+        "esprima": "2.7.x",
+        "glob": "^5.0.15",
+        "handlebars": "^4.0.1",
+        "js-yaml": "3.x",
+        "mkdirp": "0.5.x",
+        "nopt": "3.x",
+        "once": "1.x",
+        "resolve": "1.1.x",
+        "supports-color": "^3.1.0",
+        "which": "^1.1.1",
+        "wordwrap": "^1.0.0"
       },
       "dependencies": {
         "abbrev": {
@@ -1271,11 +1567,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-flag": {
@@ -1290,15 +1586,15 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
     },
     "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
     "js-yaml": {
@@ -1307,8 +1603,8 @@
       "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.1"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsbn": {
@@ -1365,8 +1661,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "load-json-file": {
@@ -1375,11 +1671,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.15",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
       }
     },
     "lodash": {
@@ -1396,8 +1692,7 @@
     "lodash.unescape": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
-      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
-      "dev": true
+      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw="
     },
     "log-driver": {
       "version": "1.2.7",
@@ -1411,18 +1706,18 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
       }
     },
     "lru-cache": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "dev": true,
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "map-obj": {
@@ -1437,16 +1732,16 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "1.2.0",
-        "normalize-package-data": "2.4.0",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
       }
     },
     "mime-db": {
@@ -1461,7 +1756,7 @@
       "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
       "dev": true,
       "requires": {
-        "mime-db": "1.37.0"
+        "mime-db": "~1.37.0"
       }
     },
     "mimic-fn": {
@@ -1476,7 +1771,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -1542,12 +1837,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "ms": {
@@ -1562,7 +1857,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -1585,13 +1880,19 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1.1.1"
+        "abbrev": "1"
       }
     },
     "normalize-package-data": {
@@ -1600,10 +1901,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.7.1",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.6.0",
-        "validate-npm-package-license": "3.0.4"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "number-is-nan": {
@@ -1630,7 +1931,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -1639,7 +1940,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "optimist": {
@@ -1648,8 +1949,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.10",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "minimist": {
@@ -1672,12 +1973,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "os-tmpdir": {
@@ -1692,7 +1993,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.2"
+        "error-ex": "^1.2.0"
       }
     },
     "path-exists": {
@@ -1701,7 +2002,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "2.0.1"
+        "pinkie-promise": "^2.0.0"
       }
     },
     "path-is-absolute": {
@@ -1716,15 +2017,21 @@
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
     "path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.15",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "performance-now": {
@@ -1751,7 +2058,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pluralize": {
@@ -1773,9 +2080,9 @@
       "dev": true
     },
     "progress": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
-      "integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
     "pseudomap": {
@@ -1808,9 +2115,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "1.1.0"
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
       }
     },
     "read-pkg-up": {
@@ -1819,8 +2126,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
       }
     },
     "readable-stream": {
@@ -1829,13 +2136,13 @@
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.2",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "redent": {
@@ -1844,14 +2151,14 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
       }
     },
     "regexpp": {
-      "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
-      "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
     },
     "repeating": {
@@ -1860,7 +2167,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "request": {
@@ -1869,26 +2176,26 @@
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.8.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.7",
-        "extend": "3.0.2",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.3",
-        "har-validator": "5.1.3",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.21",
-        "oauth-sign": "0.9.0",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.1.2",
-        "tough-cookie": "2.4.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.3.2"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
       }
     },
     "require-uncached": {
@@ -1897,9 +2204,14 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
       }
+    },
+    "requireindex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
+      "integrity": "sha1-5UBLgVV+91225JxacgBIk/4D4WI="
     },
     "resolve": {
       "version": "1.1.7",
@@ -1919,8 +2231,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "rimraf": {
@@ -1929,7 +2241,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.3"
+        "glob": "^7.0.5"
       }
     },
     "run-async": {
@@ -1938,7 +2250,7 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "2.1.0"
+        "is-promise": "^2.1.0"
       }
     },
     "rx-lite": {
@@ -1953,7 +2265,16 @@
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "dev": true,
       "requires": {
-        "rx-lite": "4.0.8"
+        "rx-lite": "*"
+      }
+    },
+    "rxjs": {
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
+      "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
@@ -1980,7 +2301,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -1996,12 +2317,14 @@
       "dev": true
     },
     "slice-ansi": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.0.0.tgz",
+      "integrity": "sha512-4j2WTWjp3GsZ+AOagyzVbzp4vWGtZ0hEZ/gDY/uTvm6MTxUfTUIsnMIFb1bn8o0RuXiqUw15H1bue8f22Vw2oQ==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0"
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
       }
     },
     "source-map": {
@@ -2011,7 +2334,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "amdefine": "1.0.1"
+        "amdefine": ">=0.0.4"
       }
     },
     "spdx-correct": {
@@ -2020,8 +2343,8 @@
       "integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "3.0.0",
-        "spdx-license-ids": "3.0.2"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -2036,8 +2359,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "2.2.0",
-        "spdx-license-ids": "3.0.2"
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -2058,15 +2381,15 @@
       "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
       "dev": true,
       "requires": {
-        "asn1": "0.2.4",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.2",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.2",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       }
     },
     "string-width": {
@@ -2075,8 +2398,8 @@
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       }
     },
     "string_decoder": {
@@ -2085,7 +2408,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -2094,15 +2417,7 @@
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "3.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        }
+        "ansi-regex": "^3.0.0"
       }
     },
     "strip-bom": {
@@ -2111,7 +2426,7 @@
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
-        "is-utf8": "0.2.1"
+        "is-utf8": "^0.2.0"
       }
     },
     "strip-indent": {
@@ -2120,7 +2435,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1"
+        "get-stdin": "^4.0.1"
       }
     },
     "strip-json-comments": {
@@ -2136,42 +2451,28 @@
       "dev": true
     },
     "table": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.1.1.tgz",
+      "integrity": "sha512-NUjapYb/qd4PeFW03HnAuOJ7OMcBkJlqeClWxeNlQ0lXGSb52oZXGzkO0/I0ARegQ2eUT1g2VDJH0eUxDRcHmw==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "ajv-keywords": "2.1.1",
-        "chalk": "2.4.1",
-        "lodash": "4.17.11",
-        "slice-ansi": "1.0.0",
-        "string-width": "2.1.1"
+        "ajv": "^6.6.1",
+        "lodash": "^4.17.11",
+        "slice-ansi": "2.0.0",
+        "string-width": "^2.1.1"
       },
       "dependencies": {
         "ajv": {
-          "version": "5.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "version": "6.6.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.1.tgz",
+          "integrity": "sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==",
           "dev": true,
           "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.1.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
           }
-        },
-        "fast-deep-equal": {
-          "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-          "dev": true
-        },
-        "json-schema-traverse": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-          "dev": true
         }
       }
     },
@@ -2193,7 +2494,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "tough-cookie": {
@@ -2202,8 +2503,8 @@
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "dev": true,
       "requires": {
-        "psl": "1.1.29",
-        "punycode": "1.4.1"
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
       },
       "dependencies": {
         "punycode": {
@@ -2220,13 +2521,19 @@
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
       "dev": true
     },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "dev": true
+    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -2241,7 +2548,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "typedarray": {
@@ -2253,8 +2560,7 @@
     "typescript": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.3.tgz",
-      "integrity": "sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==",
-      "dev": true
+      "integrity": "sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg=="
     },
     "typescript-eslint-parser": {
       "version": "21.0.1",
@@ -2262,9 +2568,9 @@
       "integrity": "sha512-rdtAzg0eTTv/+YRLBJZBAAuOHHyYiElE2HdkaOGf9kKGce811zP3JRPzDybCJQamdsxyEsMe6CyIk2JCEnw/4g==",
       "dev": true,
       "requires": {
-        "eslint-scope": "4.0.0",
-        "eslint-visitor-keys": "1.0.0",
-        "lodash": "4.17.11",
+        "eslint-scope": "^4.0.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "lodash": "^4.17.11",
         "typescript-estree": "5.0.0"
       },
       "dependencies": {
@@ -2274,8 +2580,8 @@
           "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
           "dev": true,
           "requires": {
-            "esrecurse": "4.2.1",
-            "estraverse": "4.2.0"
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
           }
         }
       }
@@ -2305,8 +2611,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "2.17.1",
-        "source-map": "0.6.1"
+        "commander": "~2.17.1",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -2329,8 +2635,8 @@
       "integrity": "sha512-g+dpmgn+XBneLmXXo+sGlW5xQEt4ErkS3mgeN2GFbremYeMBSJKr9Wf2KJplQVaiPY/f7FN6atosWYNm9ovrYg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "sprintf-js": "^1.0.3",
+        "util-deprecate": "^1.0.2"
       }
     },
     "uri-js": {
@@ -2339,7 +2645,7 @@
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
-        "punycode": "2.1.1"
+        "punycode": "^2.1.0"
       }
     },
     "util-deprecate": {
@@ -2360,8 +2666,8 @@
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
-        "spdx-correct": "3.0.2",
-        "spdx-expression-parse": "3.0.0"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "verror": {
@@ -2370,9 +2676,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "which": {
@@ -2381,7 +2687,7 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "wordwrap": {
@@ -2402,7 +2708,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
     },
     "yallist": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/silvermine/eslint-plugin-silvermine#readme",
   "dependencies": {
-    "@silvermine/eslint-config": "1.5.0",
+    "@silvermine/eslint-config": "2.0.0-preview.2",
     "class.extend": "0.9.2",
     "lodash.assign": "4.2.0",
     "underscore": "1.8.3"
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "coveralls": "3.0.2",
-    "eslint": "4.19.1",
+    "eslint": "5.10.0",
     "grunt": "1.0.3",
     "grunt-cli": "1.2.0",
     "grunt-eslint": "20.1.0",

--- a/tests/lib/rules/indent.test.js
+++ b/tests/lib/rules/indent.test.js
@@ -76,7 +76,14 @@ switchTest = formatCode(
 
 constExample = formatCode(
    'const A = 1,',
-   '      B = 2;'
+   '      B = 2;',
+   '',
+   'const myArr = [',
+   '   {',
+   '      a: 1,',
+   '      b: 2,',
+   '   },',
+   '];',
 );
 
 constInvalid = formatCode(

--- a/tests/lib/rules/indent.test.js
+++ b/tests/lib/rules/indent.test.js
@@ -9,10 +9,10 @@
 
 var rule = require('../../../lib/rules/indent'),
     formatCode = require('../../code-helper'),
-    RuleTester = require('eslint').RuleTester,
-    ruleTester = new RuleTester(),
-    validExample, switchTest, constExample,
-    invalidExample, invalidExample2, invalidExample3, constInvalid;
+    ruleTester = require('../../ruleTesters').es6(),
+    validExample, varOnlyExample, switchTest, constExample, flatTernaryValid,
+    invalidExample, invalidExample2, invalidExample3, constInvalid,
+    classInvalid;
 
 validExample = formatCode(
    'var a = 1,',
@@ -34,11 +34,67 @@ validExample = formatCode(
    '   var arr = [ 1, 2, 3 ],',
    '       noInit, andAgain;',
    '',
+   '   // This comment should be indented with the if statement',
    '   if (noInit) {',
    '      var a = 1,',
    '          b = 2;',
    '   }',
-   '}'
+   '}',
+   '',
+   'class MyClass {',
+   '   /**',
+   '    * This should be indented with the function.',
+   '    *',
+   '    * @param {number} num base number to add',
+   '    */',
+   '   constructor(num) {',
+   '      this.a = num;',
+   '   }',
+   '',
+   '   add(b) {',
+   '      return this.a + b;',
+   '   }',
+   '}',
+   '',
+   'const myClass = new MyClass();',
+   '',
+   'for (let i = 1; i < 10; i++) {',
+   '   console.log(i);',
+   '}',
+   '',
+   'myFunc().then((var1) => {',
+   '   return doSomething(var1);',
+   '});',
+   '',
+   'myFunc(',
+   '   myClass,',
+   '   a,',
+   '   b,',
+   '   c',
+   ');',
+   '',
+   'try {',
+   '   myFunc();',
+   '} catch (err) {',
+   '   console.error(err);',
+   '}',
+   '',
+   '(function() {',
+   '   doSomethingNow();',
+   '})();'
+);
+
+varOnlyExample = formatCode(
+   'var a = 1,',
+   '    b = 2,',
+   '    c = 3;'
+);
+
+flatTernaryValid = formatCode(
+   'var a =',
+   '    foo > 0 ? bar :',
+   '    foo < 0 ? baz :',
+   '    qiz;'
 );
 
 invalidExample = formatCode(
@@ -47,7 +103,17 @@ invalidExample = formatCode(
    '      b = 2;',
    '',
    '   return a + b;',
-   '}'
+   '}',
+   '',
+   'myFunc(',
+   'myClass,',
+   'a',
+   ');',
+   '',
+   'var foo = {',
+   '   bar: 1,',
+   '  baz: 2,',
+   '};'
 );
 
 invalidExample2 = formatCode(
@@ -94,6 +160,18 @@ constInvalid = formatCode(
    '    D = 4;'
 );
 
+classInvalid = formatCode(
+   'class MyClass {',
+   'constructor(num) {',
+   '   this.a = num;',
+   '}',
+   '',
+   'add(b) {',
+   '   return this.a + b;',
+   '}',
+   '}'
+);
+
 // ------------------------------------------------------------------------------
 // Tests
 // ------------------------------------------------------------------------------
@@ -113,6 +191,14 @@ ruleTester.run('indent', rule, {
          options: [ 3, { 'VariableDeclaratorOffset': { 'var': 1, 'let': 1, 'const': 3 }, 'SwitchCase': 1 } ],
          parserOptions: { ecmaVersion: 6 },
       },
+      {
+         code: varOnlyExample,
+         options: [ 3, { 'VariableDeclaratorOffset': 1 } ],
+      },
+      {
+         code: flatTernaryValid,
+         options: [ 3, { 'flatTernaryExpressions': true } ],
+      },
    ],
 
    invalid: [
@@ -121,6 +207,18 @@ ruleTester.run('indent', rule, {
          errors: [
             {
                message: 'Expected indentation of 7 spaces but found 6.',
+               type: 'Identifier',
+            },
+            {
+               message: 'Expected indentation of 3 spaces but found 0.',
+               type: 'Identifier',
+            },
+            {
+               message: 'Expected indentation of 3 spaces but found 0.',
+               type: 'Identifier',
+            },
+            {
+               message: 'Expected indentation of 3 spaces but found 2.',
                type: 'Identifier',
             },
          ],
@@ -178,6 +276,37 @@ ruleTester.run('indent', rule, {
             {
                message: 'Expected indentation of 6 spaces but found 4.',
                type: 'Identifier',
+            },
+         ],
+         options: [ 3, { 'VariableDeclaratorOffset': { 'var': 1, 'let': 1, 'const': 3 }, 'SwitchCase': 1 } ],
+         parserOptions: { ecmaVersion: 6 },
+      },
+      {
+         code: classInvalid,
+         errors: [
+            {
+               message: 'Expected indentation of 3 spaces but found 0.',
+               type: 'Identifier',
+            },
+            {
+               message: 'Expected indentation of 6 spaces but found 3.',
+               type: 'Keyword',
+            },
+            {
+               message: 'Expected indentation of 3 spaces but found 0.',
+               type: 'Punctuator',
+            },
+            {
+               message: 'Expected indentation of 3 spaces but found 0.',
+               type: 'Identifier',
+            },
+            {
+               message: 'Expected indentation of 6 spaces but found 3.',
+               type: 'Keyword',
+            },
+            {
+               message: 'Expected indentation of 3 spaces but found 0.',
+               type: 'Punctuator',
             },
          ],
          options: [ 3, { 'VariableDeclaratorOffset': { 'var': 1, 'let': 1, 'const': 3 }, 'SwitchCase': 1 } ],

--- a/tests/lib/rules/indent.test.js
+++ b/tests/lib/rules/indent.test.js
@@ -83,7 +83,7 @@ constExample = formatCode(
    '      a: 1,',
    '      b: 2,',
    '   },',
-   '];',
+   '];'
 );
 
 constInvalid = formatCode(
@@ -120,8 +120,8 @@ ruleTester.run('indent', rule, {
          code: invalidExample,
          errors: [
             {
-               message: 'Expected indentation of 7 space characters but found 6.',
-               type: 'VariableDeclarator',
+               message: 'Expected indentation of 7 spaces but found 6.',
+               type: 'Identifier',
             },
          ],
          options: [ 3, { 'VariableDeclaratorOffset': { 'var': 1, 'let': 1, 'const': 3 }, 'SwitchCase': 1 } ],
@@ -130,8 +130,8 @@ ruleTester.run('indent', rule, {
          code: invalidExample2,
          errors: [
             {
-               message: 'Expected indentation of 3 space characters but found 2.',
-               type: 'ExpressionStatement',
+               message: 'Expected indentation of 3 spaces but found 2.',
+               type: 'Identifier',
             },
          ],
          options: [ 3, { 'VariableDeclaratorOffset': { 'var': 1, 'let': 1, 'const': 3 }, 'SwitchCase': 1 } ],
@@ -140,8 +140,8 @@ ruleTester.run('indent', rule, {
          code: invalidExample3,
          errors: [
             {
-               message: 'Expected indentation of 3 space characters but found 0.',
-               type: 'ExpressionStatement',
+               message: 'Expected indentation of 3 spaces but found 0.',
+               type: 'Identifier',
             },
          ],
          options: [ 3, { 'VariableDeclaratorOffset': { 'var': 1, 'let': 1, 'const': 3 }, 'SwitchCase': 1 } ],
@@ -150,20 +150,20 @@ ruleTester.run('indent', rule, {
          code: switchTest,
          errors: [
             {
-               message: 'Expected indentation of 0 space characters but found 3.',
-               type: 'SwitchCase',
+               message: 'Expected indentation of 0 spaces but found 3.',
+               type: 'Keyword',
             },
             {
-               message: 'Expected indentation of 3 space characters but found 6.',
-               type: 'BreakStatement',
+               message: 'Expected indentation of 3 spaces but found 6.',
+               type: 'Keyword',
             },
             {
-               message: 'Expected indentation of 0 space characters but found 3.',
-               type: 'SwitchCase',
+               message: 'Expected indentation of 0 spaces but found 3.',
+               type: 'Keyword',
             },
             {
-               message: 'Expected indentation of 3 space characters but found 6.',
-               type: 'ExpressionStatement',
+               message: 'Expected indentation of 3 spaces but found 6.',
+               type: 'Identifier',
             },
          ],
          options: [ 3, { 'VariableDeclaratorOffset': { 'var': 1, 'let': 1, 'const': 3 } } ],
@@ -172,12 +172,12 @@ ruleTester.run('indent', rule, {
          code: constInvalid,
          errors: [
             {
-               message: 'Expected indentation of 6 space characters but found 3.',
-               type: 'VariableDeclarator',
+               message: 'Expected indentation of 6 spaces but found 3.',
+               type: 'Identifier',
             },
             {
-               message: 'Expected indentation of 6 space characters but found 4.',
-               type: 'VariableDeclarator',
+               message: 'Expected indentation of 6 spaces but found 4.',
+               type: 'Identifier',
             },
          ],
          options: [ 3, { 'VariableDeclaratorOffset': { 'var': 1, 'let': 1, 'const': 3 }, 'SwitchCase': 1 } ],


### PR DESCRIPTION
ESLint fixed some bugs in the indent rule. Since we have a custom fork to support 3 space indentation and lining up variable declarations, we needed to update the rule.

I "re-forked" the rule to update everything, then brought it up to our coding standards.