### PR TITLE
Fix npm madness

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "homepage": "https://github.com/silvermine/eslint-plugin-silvermine#readme",
   "dependencies": {
-    "@silvermine/eslint-config": "2.0.0-preview.2",
     "class.extend": "0.9.2",
     "lodash.assign": "4.2.0",
     "underscore": "1.8.3"
@@ -32,6 +31,7 @@
     "node": ">=6.0"
   },
   "devDependencies": {
+    "@silvermine/eslint-config": "2.0.0-preview.2",
     "coveralls": "3.0.2",
     "eslint": "5.10.0",
     "grunt": "1.0.3",


### PR DESCRIPTION
By having the config as a dependency instead of a dev dependency, we
ended up with a recursive tree of dependencies where:

 * MyProject depends on _config_
   * _config_ depends on latest version of _plugin_
     * That version of _plugin_ depends on previous version of _config_
       * Previous version of _config_ depends on previous previous
         version of _plugin_
         * Repeat until you get back to d8c1a2fd where this started
           because the config became a regular (instead of dev) dep