### PR TITLE
refactor: safely require ast-utils

### DIFF
--- a/lib/helpers/ast-utils.js
+++ b/lib/helpers/ast-utils.js
@@ -1,0 +1,16 @@
+/*
+* Rules that we fork from eslint often use the ast-utils module. This module is not made
+* public on the API, so we cannot count on it being in a certain place. In fact, the file
+* was moved in the upgrade from eslint v5 to eslint v6. In order to keep this plugin
+* compatible with both versions and prevent having to fork the entire module, this file
+* attempts to safely require the plugin from one of the two locations.
+*/
+
+/* eslint-disable global-require */
+'use strict';
+
+try {
+   module.exports = require('eslint/lib/rules/utils/ast-utils');
+} catch(e) {
+   module.exports = require('eslint/lib/util/ast-utils');
+}

--- a/lib/rules/brace-style.js
+++ b/lib/rules/brace-style.js
@@ -19,7 +19,7 @@
 
 'use strict';
 
-const astUtils = require('eslint/lib/util/ast-utils');
+const astUtils = require('../helpers/ast-utils');
 
 module.exports = {
    meta: {

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -47,7 +47,7 @@
 
 const lodash = require('lodash');
 
-const astUtils = require('eslint/lib/util/ast-utils');
+const astUtils = require('../helpers/ast-utils');
 
 const createTree = require('functional-red-black-tree');
 

--- a/lib/rules/max-statements-per-line.js
+++ b/lib/rules/max-statements-per-line.js
@@ -18,7 +18,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const astUtils = require('eslint/lib/util/ast-utils');
+const astUtils = require('../helpers/ast-utils');
 
 // ------------------------------------------------------------------------------
 // Rule Definition


### PR DESCRIPTION
The location of the ast-utils module changed in the upgrade from eslint
v5 to eslint v6. Because we are requiring this module for our forked
rules from eslint core, this prevented us from upgrading to eslint v6.

This commit adds a safe require for the module in order to make the
plugin compatible with either version of eslint.