### PR TITLE
fix: only check call indentation on functions with arguments

### DIFF
--- a/lib/rules/call-indentation.js
+++ b/lib/rules/call-indentation.js
@@ -136,7 +136,7 @@ module.exports = function(context) {
    return {
       'CallExpression': function(node) {
          // validate multi-line function indentation
-         if (node.callee.loc.end.line !== node.loc.end.line) {
+         if (node.callee.loc.end.line !== node.loc.end.line && node.arguments.length) {
             validateCallIndentation(node);
          }
       },

--- a/tests/lib/rules/call-indentation.test.js
+++ b/tests/lib/rules/call-indentation.test.js
@@ -9,8 +9,7 @@
 
 var rule = require('../../../lib/rules/call-indentation'),
     formatCode = require('../../code-helper'),
-    RuleTester = require('eslint').RuleTester,
-    ruleTester = new RuleTester(),
+    ruleTester = require('../../ruleTesters').typeScript(),
     MSG_ARG_ON_NEW_LINE = 'When arguments are on their own line, they must all be on their own line',
     MSG_PAREN_ON_NEW_LINE = 'Closing parenthesis should be on a new line',
     MSG_CALL_SAME_INDENT = 'Call expressions must begin and end with the same indentation',
@@ -231,7 +230,11 @@ validExample = formatCode(
    '   function() {',
    '      something();',
    '   }',
-   ');'
+   ');',
+   'const props = defineProps<{',
+   '   label: string;',
+   '   count: number',
+   '}>();'
 );
 
 // ------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes a crash caused by using a multiline type inside of Vue's `defineProps` because this function was checking multiline functions and expecting props.